### PR TITLE
docs+smoketest: cross-platform build matrix, 1.7B basic cap, end-to-e…

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,67 +118,115 @@ git submodule update --init --recursive
 
 > **Note:** The top-level CMake expects GGML in `./ggml` with libraries under `./ggml/build/src`.
 
-### macOS (Metal)
+### Build matrix
+
+Pick the row that matches your platform and GPU. CPU backend is always compiled in — GPU flags just add an additional backend that `QWEN3_TTS_BACKEND=auto` (the default) will prefer when available.
+
+| Platform | Mode | GGML flags (step 1) | Notes |
+|---|---|---|---|
+| macOS (Apple Silicon / Intel) | Metal + CPU (default) | *(none — Metal and Apple Accelerate BLAS are default-on)* | CoreML code predictor also enabled by default; see below. |
+| macOS | CPU only | `-DGGML_METAL=OFF -DGGML_BLAS=OFF` + top-level `-DQWEN3_TTS_COREML=OFF` | Useful for bisecting GPU issues or on machines without a usable GPU. |
+| Linux | CPU only | *(none)* | Opt into BLAS with `-DGGML_BLAS=ON -DGGML_BLAS_VENDOR=OpenBLAS` (or similar) if installed. |
+| Linux | Vulkan + CPU | `-DGGML_VULKAN=ON` | Works on AMD, NVIDIA, Intel; install the [Vulkan SDK](https://vulkan.lunarg.com/) first. |
+| Linux | CUDA + CPU | `-DGGML_CUDA=ON` | NVIDIA only; requires the [CUDA Toolkit](https://developer.nvidia.com/cuda-toolkit). |
+| Windows (MSVC) | CPU only | *(none)* | Open a Developer Command Prompt for VS 2019/2022. |
+| Windows | Vulkan + CPU | `-DGGML_VULKAN=ON` | Copy `ggml-vulkan.dll` next to `qwen3-tts-cli.exe`. |
+| Windows | CUDA + CPU | `-DGGML_CUDA=ON` | Copy `ggml-cuda.dll` next to `qwen3-tts-cli.exe`. |
+
+"GPU + CPU" is the normal operating mode for any GPU build — the GGML scheduler runs most work on GPU with automatic CPU fallback for unsupported ops. See [Backend Selection](#backend-selection) for how to force one or the other at runtime.
+
+### macOS (Metal + CoreML, default)
 
 ```bash
-# Build GGML with Metal GPU acceleration
-cmake -S ggml -B ggml/build -DGGML_METAL=ON -DCMAKE_BUILD_TYPE=Release
+# Step 1: Build GGML. Metal and Accelerate BLAS are on by default on Apple;
+# passing -DGGML_METAL=ON is optional and just makes the intent explicit.
+cmake -S ggml -B ggml/build -DCMAKE_BUILD_TYPE=Release
 cmake --build ggml/build -j$(sysctl -n hw.ncpu)
 
-# Build qwen3-tts.cpp
+# Step 2: Build qwen3-tts.cpp. QWEN3_TTS_COREML is ON by default on APPLE.
 cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j$(sysctl -n hw.ncpu)
 ```
 
-CoreML acceleration for the code predictor stage is enabled by default when the model exists. Generate it with `python scripts/setup_pipeline_models.py --coreml on`.
+CoreML acceleration for the code predictor stage is enabled by default when `models/coreml/code_predictor.mlpackage` exists. Generate that with `python scripts/setup_pipeline_models.py --coreml on`. Turn CoreML off at runtime with `QWEN3_TTS_USE_COREML=0` or at compile time with `-DQWEN3_TTS_COREML=OFF`.
 
-### Linux (Vulkan)
+### macOS (CPU only)
+
+```bash
+# Disable Metal, Accelerate BLAS, and the CoreML code predictor bridge.
+cmake -S ggml -B ggml/build -DCMAKE_BUILD_TYPE=Release \
+    -DGGML_METAL=OFF -DGGML_BLAS=OFF
+cmake --build ggml/build -j$(sysctl -n hw.ncpu)
+
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DQWEN3_TTS_COREML=OFF
+cmake --build build -j$(sysctl -n hw.ncpu)
+```
+
+You can also keep a Metal build and force CPU at runtime with `QWEN3_TTS_BACKEND=cpu` — no rebuild required.
+
+### Linux (CPU only)
+
+```bash
+cmake -S ggml -B ggml/build -DCMAKE_BUILD_TYPE=Release
+cmake --build ggml/build -j$(nproc)
+
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j$(nproc)
+```
+
+### Linux (Vulkan + CPU)
 
 Install the [Vulkan SDK](https://vulkan.lunarg.com/) first, then:
 
 ```bash
-# Build GGML with Vulkan
 cmake -S ggml -B ggml/build -DGGML_VULKAN=ON -DCMAKE_BUILD_TYPE=Release
 cmake --build ggml/build -j$(nproc)
 
-# Build qwen3-tts.cpp
 cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j$(nproc)
 ```
 
-### Linux (CUDA)
+### Linux (CUDA + CPU)
 
 Requires the [CUDA Toolkit](https://developer.nvidia.com/cuda-toolkit), then:
 
 ```bash
-# Build GGML with CUDA
 cmake -S ggml -B ggml/build -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE=Release
 cmake --build ggml/build -j$(nproc)
 
-# Build qwen3-tts.cpp
 cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j$(nproc)
 ```
 
-At runtime, set `QWEN3_TTS_BACKEND=cuda` to force the CUDA backend (see [Backend Selection](#backend-selection)).
+At runtime, set `QWEN3_TTS_BACKEND=cuda` to force the CUDA backend, or leave it at the default `auto` to let the scheduler pick it when available (see [Backend Selection](#backend-selection)).
 
 ### Windows (MSVC)
 
-Open a **Developer Command Prompt for VS 2022** (or 2019), then:
+Open a **Developer Command Prompt for VS 2022** (or 2019), then pick one:
 
 ```cmd
-:: Build GGML (CPU-only; add -DGGML_VULKAN=ON or -DGGML_CUDA=ON for GPU)
+:: CPU only (default)
 cmake -S ggml -B ggml\build -DCMAKE_BUILD_TYPE=Release
 cmake --build ggml\build --config Release
 
-:: Build qwen3-tts.cpp
+:: Vulkan + CPU (install Vulkan SDK from https://vulkan.lunarg.com/)
+:: cmake -S ggml -B ggml\build -DGGML_VULKAN=ON -DCMAKE_BUILD_TYPE=Release
+
+:: CUDA + CPU (install CUDA Toolkit)
+:: cmake -S ggml -B ggml\build -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE=Release
+
+:: Then build qwen3-tts.cpp against the chosen GGML build.
 cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build --config Release
 ```
 
-**DLL placement:** Copy `ggml.dll`, `ggml-base.dll`, `ggml-cpu.dll`, and the backend DLL (e.g. `ggml-vulkan.dll` or `ggml-cuda.dll`) into the same directory as `qwen3-tts-cli.exe`.
+**DLL placement:** Copy these DLLs next to `qwen3-tts-cli.exe` (and `libqwen3tts.dll` if you use the shared lib):
 
-For Vulkan on Windows, install the [Vulkan SDK](https://vulkan.lunarg.com/) and add `-DGGML_VULKAN=ON` to the GGML cmake line. For CUDA, add `-DGGML_CUDA=ON`.
+- Always: `ggml.dll`, `ggml-base.dll`, `ggml-cpu.dll`
+- Vulkan build: also `ggml-vulkan.dll`
+- CUDA build: also `ggml-cuda.dll` plus CUDA runtime DLLs from your toolkit install
+
+These are produced under `ggml\build\bin\Release\` (or `ggml\build\src\` depending on generator).
 
 ## Model Setup (Recommended)
 
@@ -257,18 +305,16 @@ Place both `.gguf` files in a `models/` directory.
 | `-r, --reference <file>` | Reference audio for voice cloning | (none) |
 | `--speaker-embedding <file>` | Use precomputed speaker embedding (.json/.bin) | (none) |
 | `--dump-speaker-embedding <file>` | Save extracted embedding from `--reference` | (none) |
-| `--instruction <text>` | Voice steering instruction (e.g. "Speak happily") | (none) |
+| `--instruction, --instruct <text>` | Voice steering instruction (e.g. "Speak happily") | (none) |
 | `--temperature <val>` | Sampling temperature (0 = greedy) | 0.9 |
 | `--top-k <n>` | Top-k sampling (0 = disabled) | 50 |
-| `--max-tokens <n>` | Maximum audio frames to generate | 4096 |
+| `--top-p <val>` | Top-p (nucleus) sampling cutoff | 1.0 |
+| `--max-tokens <n>` | Maximum audio frames (codec tokens) to generate | 4096 |
 | `--repetition-penalty <val>` | Repetition penalty on codebook-0 token generation | 1.05 |
 | `--seed <n>` | RNG seed for reproducible output | (random) |
 | `--no-f32-acc` | Disable f32 matmul accumulation (faster, less precise) | (off) |
 | `-l, --language <lang>` | Language: en, ru, zh, ja, ko, de, fr, es | en |
 | `-j, --threads <n>` | Number of compute threads | 4 |
-
-On macOS, CoreML code predictor is enabled by default when `models/coreml/code_predictor.mlpackage` exists.
-Set `QWEN3_TTS_USE_COREML=0` to disable it. Low-memory mode is opt-in via `QWEN3_TTS_LOW_MEM=1`.
 
 ### Speaker Embedding Workflow
 
@@ -306,15 +352,31 @@ Supported types: `q8_0`, `q4_0`, `q4_1`, `q5_0`, `q5_1`, `q4_k`, `q5_k`, `q6_k`.
 
 ### Backend Selection
 
-At runtime, each component logs its selected backend (for example, `TTSTransformer backend: MTL0` or `BLAS`).
+At runtime, each component (tokenizer, encoder, transformer, decoder) independently selects a backend and logs it — for example, `TTSTransformer backend: MTL0` or `AudioTokenizerDecoder backend: Vulkan0`.
 
-- Preferred order: `IGPU` -> `GPU` -> `ACCEL` -> `CPU`
-- Encoder and transformer can run on Metal/other accelerators with CPU fallback in the scheduler
-- Decoder now follows the same backend preference and will use Metal when available
-- `QWEN3_TTS_BACKEND` overrides runtime selection: `auto` (default), `cuda`, or `cpu`
-- `QWEN3_TTS_DEVICE` selects CUDA device index when `QWEN3_TTS_BACKEND=cuda` (default device is index 0)
-- `QWEN3_TTS_DECODER_GPU_MAX_FRAMES` controls max frames per CUDA vocoder chunk (default: `34`)
-- `QWEN3_TTS_DECODER_GPU_CONTEXT_FRAMES` controls left-context frames per CUDA vocoder chunk (default: `12`)
+`QWEN3_TTS_BACKEND` controls the selection:
+
+| Value | Effect |
+|---|---|
+| `auto` (default) | Scheduler picks the best available device in the order `IGPU` → `GPU` → `ACCEL` → `CPU`. Metal, Vulkan, and CUDA all surface through `auto` when the corresponding GGML flag was enabled at build time. |
+| `cpu` | Forces CPU-only execution regardless of what was built in. Useful for reproducibility and for bisecting GPU issues without rebuilding. |
+| `cuda` | Forces the CUDA backend. Only valid when GGML was built with `-DGGML_CUDA=ON`; otherwise falls back to CPU with a warning. |
+
+There is no separate `metal` or `vulkan` value — those are reached via `auto`. If you need to disable them, either rebuild without their GGML flag or set `QWEN3_TTS_BACKEND=cpu`.
+
+"Hybrid GPU + CPU" is the default behavior of any GPU build: the GGML scheduler keeps most work on the GPU and automatically falls back to CPU for ops the GPU backend does not support.
+
+### Runtime environment variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `QWEN3_TTS_BACKEND` | `auto` | Runtime backend override. See [Backend Selection](#backend-selection). |
+| `QWEN3_TTS_DEVICE` | `0` | CUDA device index when `QWEN3_TTS_BACKEND=cuda`. Ignored otherwise. |
+| `QWEN3_TTS_DECODER_GPU_MAX_FRAMES` | `34` | Max frames per CUDA vocoder chunk. Lower it if the GPU OOMs during decode. |
+| `QWEN3_TTS_DECODER_GPU_CONTEXT_FRAMES` | `12` | Left-context frames per CUDA vocoder chunk. |
+| `QWEN3_TTS_LOW_MEM` | unset | Set to `1` to enable low-memory pipeline mode (loads/unloads components in sequence instead of holding everything resident). |
+| `QWEN3_TTS_USE_COREML` | `1` on macOS when model exists | Set to `0` to disable the CoreML code-predictor bridge without rebuilding. |
+| `QWEN3_TTS_COREML_MODEL` | auto-detected | Absolute path override for a custom `.mlpackage` location (macOS only). |
 
 ## C API
 
@@ -429,7 +491,11 @@ The prefill embedding mirrors the Python pipeline exactly:
 ## Testing
 
 ```bash
-# Run full test suite
+# End-to-end user smoketest (macOS): build → download → synthesize on
+# Metal + CPU × F16 + Q8_0 × basic/clone/instruction + Python server
+bash scripts/run_user_smoketest.sh            # see scripts/USER_SMOKETEST.md
+
+# Run full test suite (component + E2E reference comparison)
 bash scripts/run_all_tests.sh
 
 # Individual component tests

--- a/scripts/USER_SMOKETEST.md
+++ b/scripts/USER_SMOKETEST.md
@@ -1,0 +1,205 @@
+# User-Facing Smoketest
+
+A single command that builds the project, pulls models, and exercises every
+user-visible feature end-to-end. Intended for anyone who is **not** the
+maintainer and wants to confirm a fresh checkout works on their machine.
+
+## What it covers
+
+| Area | Coverage |
+|---|---|
+| Build | `cmake` configure + build of `ggml` (Metal) and the project |
+| Models | Downloads `qwen3-tts-0.6b-f16.gguf`, `qwen3-tts-0.6b-q8_0.gguf`, tokenizer |
+| CLI synthesis | Basic text, voice cloning, instruction/steering, clone+instruction |
+| Backends | Both `QWEN3_TTS_BACKEND=auto` (Metal on macOS) and `QWEN3_TTS_BACKEND=cpu` |
+| Quantization | F16 and Q8_0 |
+| Model sizes | 0.6B always; 1.7B if you pre-drop a GGUF in `models/` |
+| Speaker embeddings | `--dump-speaker-embedding` → `--speaker-embedding` round trip |
+| Python server | Starts `server/main.py`, hits `/health`, `/v1/audio/voices`, and `/v1/audio/speech` for default + cloned voice |
+| WAV integrity | Every output is parsed: RIFF+WAVE header, `fmt`/`data` chunks, duration > 0.5s |
+
+It does **not** grade perceptual quality, only structural validity. For
+bit-accurate regression testing against the Python reference implementation,
+use `scripts/run_all_tests.sh` and `scripts/compare_e2e.py`.
+
+## Prerequisites
+
+- macOS (Apple Silicon recommended) with Xcode Command Line Tools
+  (`xcode-select --install`)
+- `cmake`, `curl`, `python3` on `$PATH` (install via Homebrew if missing)
+- ~5 GB free disk for first run (model downloads + build)
+- Network access for HuggingFace downloads on first run
+
+On Linux or Windows the script exits with code 2 — the CLI still works there,
+but the smoketest currently only drives the macOS/Metal path. See the main
+README for Linux/Vulkan, Linux/CUDA, and Windows/MSVC build recipes.
+
+## Run it
+
+```bash
+bash scripts/run_user_smoketest.sh
+```
+
+Flags:
+
+| Flag | Purpose |
+|---|---|
+| `--rebuild` | Force `cmake --build` even if binaries exist |
+| `--skip-download` | Assume models are already in `models/` (for air-gapped or flaky networks) |
+| `--skip-server` | Don't run the Python server section (skips venv + deps) |
+| `--server-port N` | Bind the server to port `N` instead of `8765` |
+
+Expected runtime:
+
+- Cold (first run, full download + build): **15–30 min**, dominated by the
+  model download.
+- Warm (binaries and models cached): **~5 min**.
+
+## Results
+
+The script prints a colorized pass/fail table at the end and writes the
+machine-readable version to `build/smoketest/results.tsv`. All generated
+artifacts land in `build/smoketest/`:
+
+```
+build/smoketest/
+├── 0.6b_f16_auto_basic.wav
+├── 0.6b_f16_auto_clone.wav
+├── 0.6b_f16_auto_instr.wav
+├── 0.6b_f16_auto_clone_instr.wav
+├── 0.6b_f16_cpu_basic.wav
+├── …
+├── embedding_reuse.wav
+├── server_default.wav
+├── server_cloned.wav
+├── speaker.json
+├── server.log
+├── results.tsv
+├── venv/
+└── voices/smoketest.json
+```
+
+Exit codes:
+
+- `0` — all required rows PASS (SKIP and WARN are allowed)
+- `1` — at least one FAIL row
+- `2` — non-macOS host
+- `3` — missing required tools
+- `4`/`5` — not a valid checkout / missing reference audio
+- `10`–`12` — build step failed
+- `20`/`21` — 0.6B model or tokenizer missing after download
+
+**WARN** rows mean the synthesis produced a valid wav but `auto` backend
+silently fell back to CPU (Metal did not initialize). The wav is fine, but
+your Metal build may be broken — check `build/smoketest/*_auto_*.log` for the
+backend-selection line.
+
+## Listen to an output
+
+```bash
+afplay build/smoketest/0.6b_f16_auto_basic.wav
+afplay build/smoketest/0.6b_f16_auto_clone.wav
+afplay build/smoketest/server_cloned.wav
+```
+
+## Running with 1.7B models
+
+There is no public prebuilt 1.7B GGUF on the default HuggingFace mirror at
+time of writing. To include 1.7B in the smoketest matrix, drop one or both of
+these files into `models/` before running:
+
+```
+models/qwen3-tts-1.7b-f16.gguf
+models/qwen3-tts-1.7b-q8_0.gguf
+```
+
+**Important — convert from the `Base` repo, not `CustomVoice` or `VoiceDesign`.**
+Only `Qwen/Qwen3-TTS-12Hz-1.7B-Base` ships the ECAPA-TDNN `speaker_encoder.*`
+weights (76 tensors); the `CustomVoice` and `VoiceDesign` repos (and community
+mirrors of them like `forkjoin-ai/qwen3-tts-12hz-1.7b-customvoice`) contain
+only the talker. Converting those will produce a GGUF that fails at runtime
+with `Error: Failed to load speaker encoder: No speaker encoder tensors found
+in model` whenever you try to voice-clone.
+
+Recommended conversion flow:
+
+```bash
+huggingface-cli login        # Qwen repos are gated
+huggingface-cli download Qwen/Qwen3-TTS-12Hz-1.7B-Base \
+    --local-dir models/hf/qwen3-tts-1.7b-base
+python scripts/convert_tts_to_gguf.py \
+    --input models/hf/qwen3-tts-1.7b-base \
+    --output models/qwen3-tts-1.7b-f16.gguf --type f16
+./build/qwen3-tts-quantize --input models/qwen3-tts-1.7b-f16.gguf \
+    --output models/qwen3-tts-1.7b-q8_0.gguf --type q8_0
+```
+
+Alternatives:
+
+1. **Project setup script** — edit the `REPOS` constants in
+   `scripts/setup_pipeline_models.py` to point at
+   `Qwen/Qwen3-TTS-12Hz-1.7B-Base` and re-run.
+2. **Community prebuilt** — e.g. the one in `gonwan/qwen3-tts.cpp` releases.
+   Verify it was produced from `Base` (not CustomVoice) before trusting the
+   cloning rows. Rename to the exact names above.
+
+The script passes `--tts-model <filename>` explicitly for every row so results
+are unambiguous. Note that `--tts-model` expects a **filename relative to the
+`-m` directory**, not a full path — the filenames above must match exactly so
+the CLI can resolve them under `models/`.
+
+### Why the 1.7B `basic` row is capped at `--max-tokens 250`
+
+Per the [HF README for Qwen3-TTS-12Hz-1.7B-Base](https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-Base):
+
+> The Base variant is voice-cloning-only and does not support text-only
+> inference without a reference audio sample.
+
+If you invoke 1.7B Base with just `-t <text>` (no `-r`, no `--instruction`),
+the model has no conditioning signal to tell it when to stop and will
+generate speech up to the `--max-tokens` budget — roughly 5.5 minutes of
+audio for an 8-word prompt. This is deterministic in greedy mode and
+identical across all backends and quantizations, so it is a model-behavior
+property, not a bug in this codebase. The `clone`, `instr`, and
+`clone_instr` rows all produce bounded output because they supply the
+required conditioning.
+
+The smoketest caps the 1.7B basic row at 250 codec tokens (~21s of audio)
+so the invocation plumbing is still exercised without making the run take
+forever. 0.6B Base bounds its own output in text-only mode so no cap is
+needed there.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `ggml submodule missing` on first run | Script will `git submodule update --init --recursive` automatically. If that fails, you're offline or lack git credentials. |
+| Metal init fails at runtime | Rebuild without CoreML: `rm -rf build && cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DQWEN3_TTS_COREML=OFF && cmake --build build -j`. Then `--rebuild`. |
+| `WARN: ran but fell back to CPU on 'auto'` | Metal didn't initialize. Check `ggml/build` was built with `-DGGML_METAL=ON` and that macOS has Metal support (Apple Silicon or AMD discrete GPU). |
+| Port 8765 already in use | `--server-port 9000` (or any free port) |
+| `pip install` fails | Network, or corporate proxy. Activate the venv manually: `source build/smoketest/venv/bin/activate && pip install -r server/requirements.txt` and read the error. |
+| First voice-clone synthesis takes ~20s | Expected. The speaker encoder lazy-loads on first `-r` call per process. Subsequent calls reuse it. |
+| First CLI run on Metal is slow | CoreML may be compiling the code-predictor mlpackage. Subsequent runs reuse the compiled cache. |
+| Downloaded a wav but it won't play | Run `validate_wav` portion manually: `python3 -c "import wave; w=wave.open('path.wav'); print(w.getnframes(), w.getframerate())"`. If that fails, check `build/smoketest/*.log` for CLI errors. |
+
+## Cleanup
+
+```bash
+rm -rf build/smoketest
+```
+
+Leaves compiled binaries (`build/qwen3-tts-cli` etc.) and downloaded models
+(`models/*.gguf`) intact. To reset everything:
+
+```bash
+rm -rf build models/qwen3-tts-*.gguf
+```
+
+## Extending the smoketest
+
+- Add a new synthesis case: append to the `run_synthesis` loop in Section 3
+  of `scripts/run_user_smoketest.sh`.
+- Add a new wav assertion: edit the `validate_wav` Python heredoc.
+- Add Linux/Windows support: replace the `uname -s` gate with a per-platform
+  `cmake` recipe and drop the `.dylib` assumption (server env var
+  `QWEN3TTS_LIB_PATH` takes `.so` or `.dll`).

--- a/scripts/run_user_smoketest.sh
+++ b/scripts/run_user_smoketest.sh
@@ -1,0 +1,651 @@
+#!/usr/bin/env bash
+# scripts/run_user_smoketest.sh
+# Automated user-facing smoketest: build -> download -> synthesize (0.6B + 1.7B if
+# present, F16 + Q8_0, Metal-auto + CPU-forced) -> speaker embedding -> Python
+# server end-to-end. Intended for non-maintainer users validating a release.
+#
+# Usage:
+#   bash scripts/run_user_smoketest.sh                # run everything
+#   bash scripts/run_user_smoketest.sh --rebuild      # force rebuild
+#   bash scripts/run_user_smoketest.sh --skip-download  # assume models already in models/
+#   bash scripts/run_user_smoketest.sh --skip-server  # skip Python server test
+#   bash scripts/run_user_smoketest.sh --server-port N
+#   bash scripts/run_user_smoketest.sh --help
+
+set -u
+set -o pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_ROOT"
+
+SMOKE_DIR="$PROJECT_ROOT/build/smoketest"
+VOICES_DIR="$SMOKE_DIR/voices"
+RESULTS_TSV="$SMOKE_DIR/results.tsv"
+SERVER_LOG="$SMOKE_DIR/server.log"
+CLONE_REF="$PROJECT_ROOT/examples/readme_clone_input.wav"
+
+HF_BASE="https://huggingface.co/koboldcpp/tts/resolve/main"
+MODEL_06_F16="models/qwen3-tts-0.6b-f16.gguf"
+MODEL_06_Q8="models/qwen3-tts-0.6b-q8_0.gguf"
+MODEL_TOKENIZER="models/qwen3-tts-tokenizer-f16.gguf"
+MODEL_17_F16="models/qwen3-tts-1.7b-f16.gguf"
+MODEL_17_Q8="models/qwen3-tts-1.7b-q8_0.gguf"
+
+REBUILD=0
+SKIP_DOWNLOAD=0
+SKIP_SERVER=0
+SERVER_PORT="8765"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --rebuild) REBUILD=1; shift ;;
+        --skip-download) SKIP_DOWNLOAD=1; shift ;;
+        --skip-server) SKIP_SERVER=1; shift ;;
+        --server-port) SERVER_PORT="$2"; shift 2 ;;
+        --help|-h)
+            grep '^#' "$0" | head -20
+            exit 0
+            ;;
+        *) echo "Unknown argument: $1" >&2; exit 64 ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Output helpers
+# ---------------------------------------------------------------------------
+
+if [[ -t 1 ]]; then
+    RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
+else
+    RED=''; GREEN=''; YELLOW=''; BLUE=''; NC=''
+fi
+
+PASS_COUNT=0
+FAIL_COUNT=0
+SKIP_COUNT=0
+WARN_COUNT=0
+
+banner() {
+    echo ""
+    echo -e "${BLUE}============================================${NC}"
+    echo -e "${BLUE} $1${NC}"
+    echo -e "${BLUE}============================================${NC}"
+}
+
+pass() { echo -e "${GREEN}[PASS]${NC} $1"; PASS_COUNT=$((PASS_COUNT+1)); }
+fail() { echo -e "${RED}[FAIL]${NC} $1"; FAIL_COUNT=$((FAIL_COUNT+1)); }
+skip() { echo -e "${YELLOW}[SKIP]${NC} $1"; SKIP_COUNT=$((SKIP_COUNT+1)); }
+warn() { echo -e "${YELLOW}[WARN]${NC} $1"; WARN_COUNT=$((WARN_COUNT+1)); }
+info() { echo -e "      $1"; }
+
+tsv() {
+    # tsv <model> <quant> <backend> <flow> <status> <seconds> <artifact>
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$@" >> "$RESULTS_TSV"
+}
+
+file_size_bytes() {
+    if stat -f%z "$1" >/dev/null 2>&1; then
+        stat -f%z "$1"
+    else
+        stat -c%s "$1" 2>/dev/null || echo 0
+    fi
+}
+
+# Validate WAV header + fmt/data chunks + duration. Prints "OK <sec>" on success,
+# or "FAIL <reason>" on failure.
+validate_wav() {
+    local wav="$1"
+    python3 - "$wav" <<'PY'
+import struct, sys, os
+p = sys.argv[1]
+try:
+    size = os.path.getsize(p)
+    if size < 10_000:
+        print(f"FAIL size={size} (<10KB)"); sys.exit(0)
+    with open(p, "rb") as f:
+        hdr = f.read(12)
+        if hdr[0:4] != b"RIFF" or hdr[8:12] != b"WAVE":
+            print(f"FAIL not-RIFF-WAVE"); sys.exit(0)
+        fmt_rate = None; data_bytes = None; bps = None; channels = None
+        while True:
+            ch = f.read(8)
+            if len(ch) < 8: break
+            tag, csize = ch[0:4], struct.unpack("<I", ch[4:8])[0]
+            if tag == b"fmt ":
+                fmt = f.read(csize)
+                _fmt_tag, channels, fmt_rate, _byterate, _blk, bps = struct.unpack("<HHIIHH", fmt[:16])
+            elif tag == b"data":
+                data_bytes = csize
+                break
+            else:
+                f.seek(csize, 1)
+        if fmt_rate is None:
+            print("FAIL no-fmt-chunk"); sys.exit(0)
+        if data_bytes is None:
+            print("FAIL no-data-chunk"); sys.exit(0)
+        if not (8000 <= fmt_rate <= 96000):
+            print(f"FAIL bad-rate={fmt_rate}"); sys.exit(0)
+        if channels not in (1, 2):
+            print(f"FAIL bad-channels={channels}"); sys.exit(0)
+        bytes_per_sample = max(1, (bps // 8) * channels)
+        samples = data_bytes // bytes_per_sample
+        duration = samples / fmt_rate
+        if duration < 0.5:
+            print(f"FAIL short-duration={duration:.2f}s"); sys.exit(0)
+        print(f"OK {duration:.2f}s rate={fmt_rate} ch={channels}")
+except Exception as e:
+    print(f"FAIL exc={e}")
+PY
+}
+
+# ---------------------------------------------------------------------------
+# Section 0: Preflight
+# ---------------------------------------------------------------------------
+
+banner "Section 0 — Preflight"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+    fail "This script targets macOS (Metal). See scripts/USER_SMOKETEST.md for Linux/Windows notes."
+    exit 2
+fi
+pass "macOS host detected ($(uname -sr))"
+
+MISSING=""
+for t in cmake curl python3; do
+    if ! command -v "$t" >/dev/null 2>&1; then MISSING="$MISSING $t"; fi
+done
+if [[ -n "$MISSING" ]]; then
+    fail "Missing required tools:$MISSING"
+    info "Install with: xcode-select --install; brew install cmake python3"
+    exit 3
+fi
+pass "Required tools present: cmake curl python3"
+
+if [[ ! -f "$PROJECT_ROOT/CMakeLists.txt" || ! -d "$PROJECT_ROOT/ggml" ]]; then
+    fail "Not a qwen3-tts.cpp checkout (missing CMakeLists.txt or ggml/)"
+    exit 4
+fi
+
+if [[ ! -f "$PROJECT_ROOT/ggml/CMakeLists.txt" ]]; then
+    info "ggml submodule missing; initializing…"
+    git submodule update --init --recursive
+fi
+pass "ggml submodule present"
+
+if [[ ! -f "$CLONE_REF" ]]; then
+    fail "Reference clone audio missing at $CLONE_REF"
+    exit 5
+fi
+
+# Disk-space warning (best-effort, macOS df reports in 512-byte blocks).
+FREE_GB=$(df -g "$PROJECT_ROOT" 2>/dev/null | awk 'NR==2 {print $4}')
+if [[ -n "${FREE_GB:-}" ]] && (( FREE_GB < 5 )); then
+    warn "Only ${FREE_GB} GB free on this volume; first run needs ~5 GB."
+fi
+
+CPU_COUNT=$(sysctl -n hw.ncpu 2>/dev/null || echo 4)
+info "Parallel build: ${CPU_COUNT} cores"
+
+rm -rf "$SMOKE_DIR"
+mkdir -p "$SMOKE_DIR" "$VOICES_DIR"
+: > "$RESULTS_TSV"
+info "Fresh artifacts directory: $SMOKE_DIR"
+
+# ---------------------------------------------------------------------------
+# Section 1: Build
+# ---------------------------------------------------------------------------
+
+banner "Section 1 — Build"
+
+need_build=0
+for bin in build/qwen3-tts-cli build/libqwen3tts.dylib build/qwen3-tts-quantize; do
+    if [[ ! -e "$bin" ]]; then
+        need_build=1
+        break
+    fi
+done
+if (( REBUILD )); then need_build=1; fi
+
+if (( need_build )); then
+    info "Building ggml with Metal…"
+    if ! cmake -S ggml -B ggml/build -DGGML_METAL=ON -DCMAKE_BUILD_TYPE=Release >"$SMOKE_DIR/cmake_ggml.log" 2>&1; then
+        fail "ggml cmake configure failed (see $SMOKE_DIR/cmake_ggml.log)"; exit 10
+    fi
+    if ! cmake --build ggml/build -j"$CPU_COUNT" >>"$SMOKE_DIR/cmake_ggml.log" 2>&1; then
+        fail "ggml build failed (see $SMOKE_DIR/cmake_ggml.log)"; exit 10
+    fi
+    pass "ggml built with Metal"
+
+    info "Building qwen3-tts.cpp…"
+    if ! cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DQWEN3_TTS_COREML=ON >"$SMOKE_DIR/cmake_project.log" 2>&1; then
+        fail "project cmake configure failed (see $SMOKE_DIR/cmake_project.log)"; exit 11
+    fi
+    if ! cmake --build build -j"$CPU_COUNT" >>"$SMOKE_DIR/cmake_project.log" 2>&1; then
+        fail "project build failed (see $SMOKE_DIR/cmake_project.log)"; exit 11
+    fi
+    pass "project built"
+else
+    pass "Build cached (pass --rebuild to force)"
+fi
+
+for bin in build/qwen3-tts-cli build/libqwen3tts.dylib build/qwen3-tts-quantize; do
+    if [[ ! -e "$bin" ]]; then
+        fail "Expected artifact missing after build: $bin"; exit 12
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Section 2: Model acquisition
+# ---------------------------------------------------------------------------
+
+banner "Section 2 — Model acquisition"
+
+mkdir -p models
+
+download_if_missing() {
+    local rel="$1"
+    local filename
+    filename="$(basename "$rel")"
+    local url="$HF_BASE/$filename"
+    if [[ -f "$rel" && $(file_size_bytes "$rel") -gt 1000000 ]]; then
+        pass "Already present: $rel ($(file_size_bytes "$rel") bytes)"
+        return 0
+    fi
+    if (( SKIP_DOWNLOAD )); then
+        skip "Download disabled; $rel missing"
+        return 1
+    fi
+    info "Downloading $url"
+    if curl -fL --retry 3 --retry-delay 2 -o "$rel" "$url" 2>&1 | tail -n 2 | sed 's/^/        /'; then
+        pass "Downloaded $rel ($(file_size_bytes "$rel") bytes)"
+    else
+        fail "Failed to download $filename"
+        rm -f "$rel"
+        return 1
+    fi
+}
+
+download_if_missing "$MODEL_06_F16" || true
+download_if_missing "$MODEL_06_Q8"  || true
+download_if_missing "$MODEL_TOKENIZER" || true
+
+if [[ ! -f "$MODEL_06_F16" && ! -f "$MODEL_06_Q8" ]]; then
+    fail "No 0.6B model available; cannot continue."
+    exit 20
+fi
+if [[ ! -f "$MODEL_TOKENIZER" ]]; then
+    fail "Tokenizer model missing; synthesis will fail."
+    exit 21
+fi
+
+# 1.7B is optional — no public prebuilt GGUF at the time of writing.
+if [[ -f "$MODEL_17_F16" ]]; then
+    pass "Found local 1.7B F16 at $MODEL_17_F16"
+fi
+if [[ -f "$MODEL_17_Q8" ]]; then
+    pass "Found local 1.7B Q8_0 at $MODEL_17_Q8"
+fi
+if [[ ! -f "$MODEL_17_F16" && ! -f "$MODEL_17_Q8" ]]; then
+    skip "1.7B models not present (see scripts/USER_SMOKETEST.md to get them)"
+fi
+
+# ---------------------------------------------------------------------------
+# Section 3: Synthesis matrix
+# ---------------------------------------------------------------------------
+
+banner "Section 3 — Synthesis matrix"
+
+# run_synthesis <model_tag> <quant_tag> <backend> <flow> <tts_model_flag> <extra_args...>
+# model_tag and quant_tag are string tags for filenames/log lines. backend is
+# "auto" (Metal preferred) or "cpu". Flow is a string like basic/clone/instr.
+run_synthesis() {
+    local model_tag="$1" quant_tag="$2" backend="$3" flow="$4"
+    shift 4
+    local out_tag="${model_tag}_${quant_tag}_${backend}_${flow}"
+    local out_wav="$SMOKE_DIR/${out_tag}.wav"
+    local log_file="$SMOKE_DIR/${out_tag}.log"
+
+    local start=$SECONDS
+    local env_prefix=()
+    if [[ "$backend" == "cpu" ]]; then
+        env_prefix=("QWEN3_TTS_BACKEND=cpu")
+    else
+        env_prefix=("QWEN3_TTS_BACKEND=auto")
+    fi
+
+    local rc=0
+    env "${env_prefix[@]}" ./build/qwen3-tts-cli -m models "$@" -o "$out_wav" \
+        >"$log_file" 2>&1 || rc=$?
+    local elapsed=$((SECONDS - start))
+
+    if (( rc != 0 )); then
+        fail "$out_tag (exit=$rc, ${elapsed}s) — see $log_file"
+        tsv "$model_tag" "$quant_tag" "$backend" "$flow" "FAIL" "$elapsed" "$out_wav"
+        return 0
+    fi
+
+    local v
+    v="$(validate_wav "$out_wav")"
+    if [[ "$v" != OK* ]]; then
+        fail "$out_tag wav invalid — $v"
+        tsv "$model_tag" "$quant_tag" "$backend" "$flow" "FAIL" "$elapsed" "$out_wav"
+        return 0
+    fi
+
+    # For the Metal (auto) case, try to confirm Metal was actually picked.
+    local status="PASS"
+    if [[ "$backend" == "auto" ]]; then
+        if grep -Eiq "backend.*metal|metal backend|ggml_metal" "$log_file"; then
+            :
+        elif grep -Eiq "using CPU backend|backend.*cpu" "$log_file"; then
+            warn "$out_tag ran but fell back to CPU on 'auto' — Metal did not initialize"
+            status="WARN"
+        fi
+    fi
+
+    if [[ "$status" == "PASS" ]]; then
+        pass "$out_tag (${elapsed}s, $v)"
+    fi
+    tsv "$model_tag" "$quant_tag" "$backend" "$flow" "$status" "$elapsed" "$out_wav"
+}
+
+TEXT_BASIC='Hello, this is a qwen3 TTS smoke test.'
+INSTRUCTION='Speak in a calm, slow voice.'
+
+# Build the matrix as a list of "model_tag quant_tag tts-model-flag-or-empty" rows.
+# `--tts-model` takes a filename relative to the model dir (-m), not a full path —
+# see src/pipeline/qwen3_tts.cpp:131-132 which prepends model_dir + "/".
+# `--tts-model` takes a filename relative to the model dir (-m), not a full path —
+# see src/pipeline/qwen3_tts.cpp:131-132 which prepends model_dir + "/".
+# Always pass it explicitly so rows are unambiguous: auto-detect would otherwise
+# prefer Q8_0 over F16 when both exist (src/pipeline/qwen3_tts.cpp:134-143).
+MATRIX=()
+[[ -f "$MODEL_06_F16" ]] && MATRIX+=("0.6b f16 --tts-model|$(basename "$MODEL_06_F16")")
+[[ -f "$MODEL_06_Q8"  ]] && MATRIX+=("0.6b q8_0 --tts-model|$(basename "$MODEL_06_Q8")")
+[[ -f "$MODEL_17_F16" ]] && MATRIX+=("1.7b f16 --tts-model|$(basename "$MODEL_17_F16")")
+[[ -f "$MODEL_17_Q8"  ]] && MATRIX+=("1.7b q8_0 --tts-model|$(basename "$MODEL_17_Q8")")
+
+for row in "${MATRIX[@]}"; do
+    # shellcheck disable=SC2206
+    parts=($row)
+    mtag="${parts[0]}"; qtag="${parts[1]}"; mflag_raw="${parts[2]:-}"
+    mflag_args=()
+    if [[ -n "$mflag_raw" ]]; then
+        IFS='|' read -r a b <<<"$mflag_raw"
+        mflag_args=("$a" "$b")
+    fi
+
+    # 1.7B Base is voice-cloning-only per Qwen's HF README — text-only
+    # inference is explicitly unsupported and causes the model to ramble to
+    # the max-tokens ceiling (~327s of speech for an 8-word prompt). Cap the
+    # basic row on 1.7B so the smoketest confirms the text-only invocation
+    # path plumbs through without waiting 15+ minutes per combo.
+    basic_extra_args=()
+    if [[ "$mtag" == "1.7b" ]]; then
+        basic_extra_args=(--max-tokens 250)
+    fi
+
+    for backend in auto cpu; do
+        run_synthesis "$mtag" "$qtag" "$backend" "basic" \
+            "${mflag_args[@]+"${mflag_args[@]}"}" "${basic_extra_args[@]+"${basic_extra_args[@]}"}" -t "$TEXT_BASIC"
+        run_synthesis "$mtag" "$qtag" "$backend" "clone" \
+            "${mflag_args[@]+"${mflag_args[@]}"}" -t "$TEXT_BASIC" -r "$CLONE_REF"
+        run_synthesis "$mtag" "$qtag" "$backend" "instr" \
+            "${mflag_args[@]+"${mflag_args[@]}"}" -t "$TEXT_BASIC" --instruction "$INSTRUCTION"
+        run_synthesis "$mtag" "$qtag" "$backend" "clone_instr" \
+            "${mflag_args[@]+"${mflag_args[@]}"}" -t "$TEXT_BASIC" -r "$CLONE_REF" --instruction "$INSTRUCTION"
+    done
+done
+
+# ---------------------------------------------------------------------------
+# Section 4: Speaker embedding workflow
+# ---------------------------------------------------------------------------
+
+banner "Section 4 — Speaker embedding workflow"
+
+EMB_JSON="$SMOKE_DIR/speaker.json"
+EMB_TMP_WAV="$SMOKE_DIR/_embedding_dump_tmp.wav"
+EMB_REUSE_WAV="$SMOKE_DIR/embedding_reuse.wav"
+
+start=$SECONDS
+if QWEN3_TTS_BACKEND=auto ./build/qwen3-tts-cli -m models \
+        -r "$CLONE_REF" \
+        --dump-speaker-embedding "$EMB_JSON" \
+        -t "embedding extraction" -o "$EMB_TMP_WAV" \
+        >"$SMOKE_DIR/embedding_dump.log" 2>&1; then
+    elapsed=$((SECONDS - start))
+    if [[ -s "$EMB_JSON" ]]; then
+        if python3 - "$EMB_JSON" <<'PY'
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+    n = d["embedding_size"]; arr = d["data"]
+    assert isinstance(arr, list) and len(arr) == n, f"len mismatch {len(arr)} vs {n}"
+    assert all(isinstance(x, (int,float)) for x in arr[:4]), "non-numeric"
+    sys.exit(0)
+except Exception as e:
+    print(e); sys.exit(1)
+PY
+        then
+            pass "Speaker embedding dumped (${elapsed}s) → $EMB_JSON"
+            tsv "embed" "-" "auto" "dump" "PASS" "$elapsed" "$EMB_JSON"
+        else
+            fail "speaker.json schema check failed"
+            tsv "embed" "-" "auto" "dump" "FAIL" "$elapsed" "$EMB_JSON"
+        fi
+    else
+        fail "Embedding file missing or empty"
+        tsv "embed" "-" "auto" "dump" "FAIL" "$elapsed" "$EMB_JSON"
+    fi
+else
+    fail "dump-speaker-embedding CLI call failed"
+    tsv "embed" "-" "auto" "dump" "FAIL" "0" "$EMB_JSON"
+fi
+
+if [[ -s "$EMB_JSON" ]]; then
+    start=$SECONDS
+    if QWEN3_TTS_BACKEND=auto ./build/qwen3-tts-cli -m models \
+            --speaker-embedding "$EMB_JSON" \
+            -t "Reusing cached speaker embedding from disk." \
+            -o "$EMB_REUSE_WAV" \
+            >"$SMOKE_DIR/embedding_reuse.log" 2>&1; then
+        elapsed=$((SECONDS - start))
+        v="$(validate_wav "$EMB_REUSE_WAV")"
+        if [[ "$v" == OK* ]]; then
+            pass "Speaker embedding reuse (${elapsed}s, $v)"
+            tsv "embed" "-" "auto" "reuse" "PASS" "$elapsed" "$EMB_REUSE_WAV"
+        else
+            fail "embedding_reuse.wav invalid — $v"
+            tsv "embed" "-" "auto" "reuse" "FAIL" "$elapsed" "$EMB_REUSE_WAV"
+        fi
+    else
+        fail "speaker-embedding CLI call failed"
+        tsv "embed" "-" "auto" "reuse" "FAIL" "0" "$EMB_REUSE_WAV"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Section 5: Python server
+# ---------------------------------------------------------------------------
+
+SERVER_PID=""
+cleanup_server() {
+    if [[ -n "$SERVER_PID" ]]; then
+        kill "$SERVER_PID" 2>/dev/null || true
+        wait "$SERVER_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup_server EXIT
+
+if (( SKIP_SERVER )); then
+    banner "Section 5 — Python server (skipped by flag)"
+    skip "Server test skipped (--skip-server)"
+else
+    banner "Section 5 — Python server"
+
+    VENV="$SMOKE_DIR/venv"
+    info "Creating venv at $VENV"
+    if ! python3 -m venv "$VENV" >"$SMOKE_DIR/venv.log" 2>&1; then
+        fail "Failed to create venv"
+        tsv "server" "-" "auto" "setup" "FAIL" "0" "$VENV"
+    else
+        # shellcheck disable=SC1091
+        source "$VENV/bin/activate"
+        if ! pip install --quiet --upgrade pip >>"$SMOKE_DIR/venv.log" 2>&1; then
+            warn "pip upgrade failed (non-fatal)"
+        fi
+        if ! pip install --quiet -r server/requirements.txt >>"$SMOKE_DIR/venv.log" 2>&1; then
+            fail "pip install of server requirements failed (see $SMOKE_DIR/venv.log)"
+            tsv "server" "-" "auto" "setup" "FAIL" "0" "$VENV"
+        else
+            pass "Python server deps installed"
+
+            # Seed a voice from the dumped embedding so the server has >1 voice.
+            if [[ -s "$EMB_JSON" ]]; then
+                cp "$EMB_JSON" "$VOICES_DIR/smoketest.json"
+                info "Seeded voice 'smoketest' in $VOICES_DIR"
+            fi
+
+            info "Starting server on 127.0.0.1:$SERVER_PORT"
+            QWEN3TTS_MODEL_DIR="$PROJECT_ROOT/models" \
+            QWEN3TTS_VOICES_DIR="$VOICES_DIR" \
+            QWEN3TTS_LIB_PATH="$PROJECT_ROOT/build/libqwen3tts.dylib" \
+            QWEN3TTS_HOST="127.0.0.1" \
+            QWEN3TTS_PORT="$SERVER_PORT" \
+                python server/main.py >"$SERVER_LOG" 2>&1 &
+            SERVER_PID=$!
+
+            # Readiness probe (/health is defined in server/main.py).
+            ready=0
+            for _ in $(seq 1 60); do
+                if curl -fsS "http://127.0.0.1:$SERVER_PORT/health" -o /dev/null 2>/dev/null; then
+                    ready=1
+                    break
+                fi
+                if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+                    break
+                fi
+                sleep 1
+            done
+
+            if (( !ready )); then
+                fail "Server did not become ready within 60s (log: $SERVER_LOG)"
+                tsv "server" "-" "auto" "startup" "FAIL" "60" "$SERVER_LOG"
+            else
+                pass "Server responded to /health"
+                tsv "server" "-" "auto" "startup" "PASS" "0" "$SERVER_LOG"
+
+                # Voice listing endpoint
+                if curl -fsS "http://127.0.0.1:$SERVER_PORT/v1/audio/voices" \
+                        -o "$SMOKE_DIR/server_voices.json" 2>/dev/null; then
+                    if python3 -c 'import json,sys;d=json.load(open(sys.argv[1]));assert "voices" in d and "default" in d["voices"]' \
+                            "$SMOKE_DIR/server_voices.json" 2>/dev/null; then
+                        pass "/v1/audio/voices returned valid list"
+                    else
+                        warn "/v1/audio/voices returned malformed JSON"
+                    fi
+                else
+                    warn "/v1/audio/voices request failed"
+                fi
+
+                # Default voice
+                start=$SECONDS
+                if curl -fsS -X POST "http://127.0.0.1:$SERVER_PORT/v1/audio/speech" \
+                        -H 'Content-Type: application/json' \
+                        -d '{"input":"Server default voice end to end test.","model":"qwen3-tts"}' \
+                        -o "$SMOKE_DIR/server_default.wav"; then
+                    elapsed=$((SECONDS - start))
+                    v="$(validate_wav "$SMOKE_DIR/server_default.wav")"
+                    if [[ "$v" == OK* ]]; then
+                        pass "Server /v1/audio/speech default voice (${elapsed}s, $v)"
+                        tsv "server" "-" "auto" "default_voice" "PASS" "$elapsed" "$SMOKE_DIR/server_default.wav"
+                    else
+                        fail "server_default.wav invalid — $v"
+                        tsv "server" "-" "auto" "default_voice" "FAIL" "$elapsed" "$SMOKE_DIR/server_default.wav"
+                    fi
+                else
+                    fail "/v1/audio/speech (default) returned non-2xx"
+                    tsv "server" "-" "auto" "default_voice" "FAIL" "0" "$SMOKE_DIR/server_default.wav"
+                fi
+
+                # Cloned voice (only if we seeded it)
+                if [[ -s "$VOICES_DIR/smoketest.json" ]]; then
+                    start=$SECONDS
+                    if curl -fsS -X POST "http://127.0.0.1:$SERVER_PORT/v1/audio/speech" \
+                            -H 'Content-Type: application/json' \
+                            -d '{"input":"Server cloned voice end to end test.","model":"qwen3-tts","voice":"smoketest"}' \
+                            -o "$SMOKE_DIR/server_cloned.wav"; then
+                        elapsed=$((SECONDS - start))
+                        v="$(validate_wav "$SMOKE_DIR/server_cloned.wav")"
+                        if [[ "$v" == OK* ]]; then
+                            pass "Server /v1/audio/speech cloned voice (${elapsed}s, $v)"
+                            tsv "server" "-" "auto" "cloned_voice" "PASS" "$elapsed" "$SMOKE_DIR/server_cloned.wav"
+                        else
+                            fail "server_cloned.wav invalid — $v"
+                            tsv "server" "-" "auto" "cloned_voice" "FAIL" "$elapsed" "$SMOKE_DIR/server_cloned.wav"
+                        fi
+                    else
+                        fail "/v1/audio/speech (cloned) returned non-2xx"
+                        tsv "server" "-" "auto" "cloned_voice" "FAIL" "0" "$SMOKE_DIR/server_cloned.wav"
+                    fi
+                fi
+            fi
+
+            cleanup_server
+            SERVER_PID=""
+        fi
+        deactivate 2>/dev/null || true
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Section 6: Summary
+# ---------------------------------------------------------------------------
+
+banner "Section 6 — Summary"
+
+if [[ -s "$RESULTS_TSV" ]]; then
+    echo ""
+    printf '%-8s %-6s %-6s %-14s %-6s %-7s  %s\n' \
+        "MODEL" "QUANT" "BACKEND" "FLOW" "STATUS" "TIME_s" "ARTIFACT"
+    printf '%-8s %-6s %-6s %-14s %-6s %-7s  %s\n' \
+        "--------" "------" "------" "--------------" "------" "-------" "--------"
+    while IFS=$'\t' read -r m q b f s t a; do
+        # Colorize status.
+        case "$s" in
+            PASS) sc="${GREEN}${s}${NC}" ;;
+            FAIL) sc="${RED}${s}${NC}" ;;
+            WARN) sc="${YELLOW}${s}${NC}" ;;
+            SKIP) sc="${YELLOW}${s}${NC}" ;;
+            *)    sc="$s" ;;
+        esac
+        printf '%-8s %-6s %-6s %-14s %-16b %-7s  %s\n' \
+            "$m" "$q" "$b" "$f" "$sc" "$t" "$a"
+    done < "$RESULTS_TSV"
+    echo ""
+fi
+
+echo "Passes:   $PASS_COUNT"
+echo "Warnings: $WARN_COUNT"
+echo "Skips:    $SKIP_COUNT"
+echo "Failures: $FAIL_COUNT"
+echo ""
+echo "Raw results: $RESULTS_TSV"
+echo "Listen to an output:  afplay $SMOKE_DIR/0.6b_f16_auto_basic.wav"
+echo ""
+
+if (( FAIL_COUNT > 0 )); then
+    echo -e "${RED}Smoketest FAILED.${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}Smoketest PASSED.${NC}"
+if (( WARN_COUNT > 0 )); then
+    echo -e "${YELLOW}(${WARN_COUNT} warning(s) — review for Metal fallback etc.)${NC}"
+fi
+exit 0

--- a/server/README.md
+++ b/server/README.md
@@ -4,12 +4,12 @@ OpenAI-compatible TTS HTTP server backed by the qwen3-tts.cpp shared library.
 
 ## Prerequisites
 
-1. Build qwen3-tts.cpp with the shared library (done by default):
+1. Build qwen3-tts.cpp with the shared library (done by default — works on macOS/Linux/Windows, CPU-only or any GPU backend; see main README for per-platform build instructions):
    ```bash
    cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
    cmake --build build -j$(nproc)
    ```
-   This produces `build/libqwen3tts.{so,dylib}`.
+   This produces `build/libqwen3tts.{so,dylib,dll}`. On Windows, copy the GGML DLLs (`ggml.dll`, `ggml-base.dll`, `ggml-cpu.dll`, and any backend DLL) into the same directory as `libqwen3tts.dll` before launching the server, or point `QWEN3TTS_LIB_PATH` at an absolute path whose directory holds them.
 
 2. Download or convert GGUF models into `models/` (see main README).
 


### PR DESCRIPTION
…nd user smoketest

README.md: restructure Build section around a platform × backend matrix covering macOS (Metal, CPU-only), Linux (CPU-only, Vulkan, CUDA), and Windows MSVC (CPU-only, Vulkan, CUDA). Clarify that Metal + Accelerate BLAS are default-on on Apple, that CPU backend is always compiled in, and that "GPU + CPU" is the default behavior of any GPU build via the GGML scheduler. Add explicit Backend Selection table (auto / cpu / cuda) noting that Metal and Vulkan reach you through auto with no separate env value. Add Runtime environment variables table covering all seven real vars (BACKEND, DEVICE, DECODER_GPU_MAX_FRAMES, DECODER_GPU_CONTEXT_FRAMES, LOW_MEM, USE_COREML, COREML_MODEL). Add missing --top-p flag and --instruct alias in the CLI options table; document compile-time -DQWEN3_TTS_COREML=OFF and runtime QWEN3_TTS_USE_COREML=0.

scripts/run_user_smoketest.sh + scripts/USER_SMOKETEST.md: new end-to-end smoketest that builds the project, downloads/auto-detects models, and drives the full feature surface on macOS Metal — basic, voice clone, instruction, and clone+instruction synthesis × Metal auto + CPU × F16 + Q8_0 for 0.6B, and 1.7B when its GGUFs are pre-placed — plus the speaker-embedding dump/reuse round-trip and the OpenAI- compatible Python server's /health, /v1/audio/voices, and /v1/audio/speech endpoints. Writes a machine-readable results.tsv and a color-coded summary. Confirmed 37/37 PASS with 0.6B Base and 1.7B Base GGUFs converted from the official Qwen HF repos.

scripts/run_user_smoketest.sh: cap the 1.7B basic row at --max-tokens 250 (~21s of audio). Per the Qwen/Qwen3-TTS-12Hz-1.7B-Base README, the Base variant is voice-cloning-only and does not support text-only inference without a reference audio sample. Without the cap, 1.7B Base text-only synthesis rambles to the full max-tokens budget (~327s for an 8-word prompt). Deterministic in greedy mode across Metal, CUDA- equivalent (CPU), and Q8_0 backends, which rules out a precision or code bug on our side. scripts/USER_SMOKETEST.md documents the Base-vs-CustomVoice/VoiceDesign gap (only Base ships the ECAPA-TDNN speaker_encoder tensors) and gives a full conversion recipe.

server/README.md: include .dll in the shared-library extension list and note the GGML DLL co-location requirement for Windows deployments.