### PR TITLE
Add idle GPU weight RAM offload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ models/hf/
 
 # Claude Code runtime state
 .claude/
+.worktrees/
 
 # Reference outputs (generated)
 reference/*.bin

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ Thumbs.db
 debug_*.bin
 reference/decoder_debug/
 reference/debug/
+/build-pr-cuda86
+/build-pr-default-cuda

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ else()
 endif()
 
 # Common library (gguf_loader + coreml bridge — compiled once, shared by all)
-set(COMMON_SOURCES src/common/gguf_loader.cpp src/common/speaker_embedding_io.cpp)
+set(COMMON_SOURCES src/common/gguf_loader.cpp src/common/speaker_embedding_io.cpp src/common/gpu_offload_policy.cpp)
 if(APPLE AND QWEN3_TTS_COREML)
     list(APPEND COMMON_SOURCES src/common/coreml_code_predictor.mm)
     set_source_files_properties(src/common/coreml_code_predictor.mm PROPERTIES COMPILE_FLAGS "-fobjc-arc")
@@ -149,6 +149,14 @@ target_link_libraries(test_tokenizer PRIVATE
     Threads::Threads
 )
 
+# Test executable for GPU offload policy
+add_executable(test_gpu_offload_policy
+    tests/test_gpu_offload_policy.cpp
+)
+target_link_libraries(test_gpu_offload_policy PRIVATE
+    qwen3_tts_common
+)
+
 # Test executable for audio encoder
 add_executable(test_encoder
     tests/test_encoder.cpp
@@ -194,6 +202,7 @@ install(TARGETS text_tokenizer tts_transformer audio_tokenizer_encoder audio_cod
 )
 install(FILES
     src/common/gguf_loader.h
+    src/common/gpu_offload_policy.h
     src/common/coreml_code_predictor.h
     src/tokenizer/text_tokenizer.h
     src/transformer/tts_transformer.h
@@ -208,6 +217,10 @@ install(FILES
 enable_testing()
 add_test(NAME tokenizer_test
     COMMAND test_tokenizer
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+add_test(NAME gpu_offload_policy_test
+    COMMAND test_gpu_offload_policy
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 add_test(NAME encoder_test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,14 @@ target_link_libraries(test_encoder PRIVATE
     Threads::Threads
 )
 
+add_executable(test_audio_tokenizer_encoder_lifecycle
+    tests/test_audio_tokenizer_encoder_lifecycle.cpp
+)
+target_link_libraries(test_audio_tokenizer_encoder_lifecycle PRIVATE
+    audio_tokenizer_encoder
+    Threads::Threads
+)
+
 # Test executable for transformer
 add_executable(test_transformer
     tests/test_transformer.cpp
@@ -238,6 +246,10 @@ add_test(NAME weight_residency_test
 )
 add_test(NAME encoder_test
     COMMAND test_encoder --tokenizer models/qwen3-tts-0.6b-f16.gguf --audio clone.wav --reference reference/ref_audio_embedding.bin
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+add_test(NAME audio_tokenizer_encoder_lifecycle_test
+    COMMAND test_audio_tokenizer_encoder_lifecycle
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 add_test(NAME transformer_test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ else()
 endif()
 
 # Common library (gguf_loader + coreml bridge — compiled once, shared by all)
-set(COMMON_SOURCES src/common/gguf_loader.cpp src/common/speaker_embedding_io.cpp src/common/gpu_offload_policy.cpp)
+set(COMMON_SOURCES src/common/gguf_loader.cpp src/common/speaker_embedding_io.cpp src/common/gpu_offload_policy.cpp src/common/weight_residency.cpp)
 if(APPLE AND QWEN3_TTS_COREML)
     list(APPEND COMMON_SOURCES src/common/coreml_code_predictor.mm)
     set_source_files_properties(src/common/coreml_code_predictor.mm PROPERTIES COMPILE_FLAGS "-fobjc-arc")
@@ -157,6 +157,14 @@ target_link_libraries(test_gpu_offload_policy PRIVATE
     qwen3_tts_common
 )
 
+# Test executable for weight residency helpers
+add_executable(test_weight_residency
+    tests/test_weight_residency.cpp
+)
+target_link_libraries(test_weight_residency PRIVATE
+    qwen3_tts_common
+)
+
 # Test executable for audio encoder
 add_executable(test_encoder
     tests/test_encoder.cpp
@@ -203,6 +211,7 @@ install(TARGETS text_tokenizer tts_transformer audio_tokenizer_encoder audio_cod
 install(FILES
     src/common/gguf_loader.h
     src/common/gpu_offload_policy.h
+    src/common/weight_residency.h
     src/common/coreml_code_predictor.h
     src/tokenizer/text_tokenizer.h
     src/transformer/tts_transformer.h
@@ -221,6 +230,10 @@ add_test(NAME tokenizer_test
 )
 add_test(NAME gpu_offload_policy_test
     COMMAND test_gpu_offload_policy
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+add_test(NAME weight_residency_test
+    COMMAND test_weight_residency
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 add_test(NAME encoder_test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,4 +292,5 @@ add_test(NAME gpu_idle_offload_validation_test
 )
 set_tests_properties(gpu_idle_offload_validation_test PROPERTIES
     LABELS "manual;gpu"
+    SKIP_REGULAR_EXPRESSION "SKIP:"
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,6 +210,17 @@ target_link_libraries(test_decoder PRIVATE
     Threads::Threads
 )
 
+add_executable(test_pipeline_offload_lifecycle
+    tests/test_pipeline_offload_lifecycle.cpp
+)
+target_link_libraries(test_pipeline_offload_lifecycle PRIVATE
+    qwen3_tts
+    Threads::Threads
+)
+target_compile_definitions(test_pipeline_offload_lifecycle PRIVATE
+    QWEN3_TTS_ENABLE_TEST_DIAGNOSTICS
+)
+
 # Install targets
 install(TARGETS text_tokenizer tts_transformer audio_tokenizer_encoder audio_codec_encoder audio_tokenizer_decoder qwen3_tts qwen3tts_shared qwen3-tts-cli
     ARCHIVE DESTINATION lib
@@ -258,5 +269,9 @@ add_test(NAME transformer_test
 )
 add_test(NAME decoder_test
     COMMAND test_decoder
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+add_test(NAME pipeline_offload_lifecycle_test
+    COMMAND test_pipeline_offload_lifecycle
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,6 +221,17 @@ target_compile_definitions(test_pipeline_offload_lifecycle PRIVATE
     QWEN3_TTS_ENABLE_TEST_DIAGNOSTICS
 )
 
+add_executable(test_gpu_idle_offload_validation
+    tests/test_gpu_idle_offload_validation.cpp
+)
+target_link_libraries(test_gpu_idle_offload_validation PRIVATE
+    qwen3_tts
+    Threads::Threads
+)
+target_compile_definitions(test_gpu_idle_offload_validation PRIVATE
+    QWEN3_TTS_ENABLE_TEST_DIAGNOSTICS
+)
+
 # Install targets
 install(TARGETS text_tokenizer tts_transformer audio_tokenizer_encoder audio_codec_encoder audio_tokenizer_decoder qwen3_tts qwen3tts_shared qwen3-tts-cli
     ARCHIVE DESTINATION lib
@@ -274,4 +285,11 @@ add_test(NAME decoder_test
 add_test(NAME pipeline_offload_lifecycle_test
     COMMAND test_pipeline_offload_lifecycle
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+add_test(NAME gpu_idle_offload_validation_test
+    COMMAND test_gpu_idle_offload_validation
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+set_tests_properties(gpu_idle_offload_validation_test PROPERTIES
+    LABELS "manual;gpu"
 )

--- a/README.md
+++ b/README.md
@@ -435,6 +435,7 @@ For CUDA:
 
 ```bash
 cmake -S ggml -B ggml/build -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE=Release
+cmake --build ggml/build -j
 cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build --target test_gpu_idle_offload_validation -j
 QWEN3_TTS_RUN_GPU_OFFLOAD_VALIDATION=1 \
@@ -447,6 +448,7 @@ For Vulkan, build GGML with Vulkan and leave backend selection on `auto` unless 
 
 ```bash
 cmake -S ggml -B ggml/build -DGGML_VULKAN=ON -DCMAKE_BUILD_TYPE=Release
+cmake --build ggml/build -j
 cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build --target test_gpu_idle_offload_validation -j
 QWEN3_TTS_RUN_GPU_OFFLOAD_VALIDATION=1 \
@@ -457,6 +459,7 @@ ctest --test-dir build -R gpu_idle_offload_validation --output-on-failure
 Expected validation signs:
 
 - Logs show CUDA or Vulkan backends for `TTSTransformer` and `AudioTokenizerDecoder`.
+- For Vulkan validation, those backend logs must specifically show Vulkan. If `auto` selects another GPU backend, disable that backend in the GGML build or rebuild with only Vulkan enabled for this check.
 - Logs show `GPU idle RAM offload: transformer copied ... to host RAM` and `GPU idle RAM offload: decoder copied ... to host RAM`.
 - GPU memory rises during load/synthesis, drops after the idle timeout, and rises again for the second synthesis. Use `nvidia-smi`, `nvtop`, `radeontop`, vendor tooling, or Vulkan memory tooling as appropriate.
 - The validation test exits successfully after the post-offload synthesis.
@@ -465,10 +468,11 @@ Negative checks:
 
 ```bash
 QWEN3_TTS_LOW_MEM=1 QWEN3_TTS_GPU_OFFLOAD_IDLE_SECS=2 ./build/qwen3-tts-cli -m models -t "low memory check" -o /tmp/qwen-lowmem.wav
-QWEN3_TTS_RUN_GPU_OFFLOAD_VALIDATION=1 QWEN3_TTS_BACKEND=cpu ctest --test-dir build -R gpu_idle_offload_validation --output-on-failure
+QWEN3_TTS_BACKEND=cpu QWEN3_TTS_GPU_OFFLOAD_IDLE_SECS=1 ./build/test_pipeline_offload_lifecycle
+QWEN3_TTS_RUN_GPU_OFFLOAD_VALIDATION=1 QWEN3_TTS_BACKEND=cpu ./build/test_gpu_idle_offload_validation
 ```
 
-Low-memory mode should log that idle GPU RAM offload is disabled and keep the existing staged load/unload behavior. CPU and Metal paths should not production-offload weights to RAM.
+Low-memory mode should log that idle GPU RAM offload is disabled and keep the existing staged load/unload behavior. The CPU lifecycle check should pass without production-offloading weights. The final GPU validation guard should exit non-zero with `QWEN3_TTS_BACKEND=cpu cannot validate CUDA/Vulkan idle offload`; that confirms the CUDA/Vulkan validation gate is not being satisfied by a CPU run. Metal paths should log as ineligible/disabled for idle GPU RAM offload.
 
 ### Runtime environment variables
 

--- a/README.md
+++ b/README.md
@@ -427,6 +427,49 @@ There is no separate `metal` or `vulkan` value — those are reached via `auto`.
 
 Idle GPU RAM offload is intended for long-lived CUDA/Vulkan processes that want to release VRAM between requests. It copies weights to host RAM after the idle timeout fires, frees GPU weight buffers, and reloads from RAM on the next tensor-using request. It does not stream layers during inference and is disabled for Metal/CPU backends.
 
+#### Validating idle GPU RAM offload
+
+Use the opt-in validation test on a machine with the GGUF models and a CUDA or Vulkan GGML build. The test keeps a `Qwen3TTS` instance alive across two synthesis requests, waits for the production idle worker, requires transformer and decoder weights to move to RAM, then verifies the next synthesis reloads them successfully.
+
+For CUDA:
+
+```bash
+cmake -S ggml -B ggml/build -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE=Release
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build --target test_gpu_idle_offload_validation -j
+QWEN3_TTS_RUN_GPU_OFFLOAD_VALIDATION=1 \
+QWEN3_TTS_BACKEND=cuda \
+QWEN3_TTS_MODEL_DIR=models \
+ctest --test-dir build -R gpu_idle_offload_validation --output-on-failure
+```
+
+For Vulkan, build GGML with Vulkan and leave backend selection on `auto` unless your local build has a custom selector:
+
+```bash
+cmake -S ggml -B ggml/build -DGGML_VULKAN=ON -DCMAKE_BUILD_TYPE=Release
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build --target test_gpu_idle_offload_validation -j
+QWEN3_TTS_RUN_GPU_OFFLOAD_VALIDATION=1 \
+QWEN3_TTS_MODEL_DIR=models \
+ctest --test-dir build -R gpu_idle_offload_validation --output-on-failure
+```
+
+Expected validation signs:
+
+- Logs show CUDA or Vulkan backends for `TTSTransformer` and `AudioTokenizerDecoder`.
+- Logs show `GPU idle RAM offload: transformer copied ... to host RAM` and `GPU idle RAM offload: decoder copied ... to host RAM`.
+- GPU memory rises during load/synthesis, drops after the idle timeout, and rises again for the second synthesis. Use `nvidia-smi`, `nvtop`, `radeontop`, vendor tooling, or Vulkan memory tooling as appropriate.
+- The validation test exits successfully after the post-offload synthesis.
+
+Negative checks:
+
+```bash
+QWEN3_TTS_LOW_MEM=1 QWEN3_TTS_GPU_OFFLOAD_IDLE_SECS=2 ./build/qwen3-tts-cli -m models -t "low memory check" -o /tmp/qwen-lowmem.wav
+QWEN3_TTS_RUN_GPU_OFFLOAD_VALIDATION=1 QWEN3_TTS_BACKEND=cpu ctest --test-dir build -R gpu_idle_offload_validation --output-on-failure
+```
+
+Low-memory mode should log that idle GPU RAM offload is disabled and keep the existing staged load/unload behavior. CPU and Metal paths should not production-offload weights to RAM.
+
 ### Runtime environment variables
 
 | Variable | Default | Purpose |

--- a/README.md
+++ b/README.md
@@ -425,6 +425,8 @@ There is no separate `metal` or `vulkan` value — those are reached via `auto`.
 
 "Hybrid GPU + CPU" is the default behavior of any GPU build: the GGML scheduler keeps most work on the GPU and automatically falls back to CPU for ops the GPU backend does not support.
 
+Idle GPU RAM offload is intended for long-lived CUDA/Vulkan processes that want to release VRAM between requests. It copies weights to host RAM after the idle timeout fires, frees GPU weight buffers, and reloads from RAM on the next tensor-using request. It does not stream layers during inference and is disabled for Metal/CPU backends.
+
 ### Runtime environment variables
 
 | Variable | Default | Purpose |
@@ -434,6 +436,7 @@ There is no separate `metal` or `vulkan` value — those are reached via `auto`.
 | `QWEN3_TTS_DECODER_GPU_MAX_FRAMES` | `34` | Max frames per CUDA vocoder chunk. Lower it if the GPU OOMs during decode. |
 | `QWEN3_TTS_DECODER_GPU_CONTEXT_FRAMES` | `12` | Left-context frames per CUDA vocoder chunk. |
 | `QWEN3_TTS_LOW_MEM` | unset | Set to `1` to enable low-memory pipeline mode (loads/unloads components in sequence instead of holding everything resident). |
+| `QWEN3_TTS_GPU_OFFLOAD_IDLE_SECS` | `0` | CUDA/Vulkan only. Positive values enable idle RAM offload after N idle seconds. Disabled when `QWEN3_TTS_LOW_MEM=1`. |
 | `QWEN3_TTS_USE_COREML` | `1` on macOS when model exists | Set to `0` to disable the CoreML code-predictor bridge without rebuilding. |
 | `QWEN3_TTS_COREML_MODEL` | auto-detected | Absolute path override for a custom `.mlpackage` location (macOS only). |
 

--- a/docs/superpowers/plans/2026-05-23-idle-gpu-weight-ram-offload.md
+++ b/docs/superpowers/plans/2026-05-23-idle-gpu-weight-ram-offload.md
@@ -1,0 +1,1103 @@
+# Idle GPU Weight RAM Offload Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an opt-in CUDA/Vulkan idle timeout that copies model weights from GPU memory to host RAM, frees idle GPU weight buffers, and reloads from RAM before the next backend-tensor operation.
+
+**Architecture:** Add a reusable common tensor-residency helper, then apply it to `TTSTransformer` and `AudioTokenizerDecoder`. `Qwen3TTS` owns the policy, lifecycle mutex, worker thread, guarded public operations, and low-memory precedence; component classes own their own offload/reload mechanics.
+
+**Tech Stack:** C++17, GGML backend APIs, CMake standalone test executables, existing `fprintf(stderr, ...)` logging style.
+
+---
+
+## Reference Documents
+
+- Spec: `docs/superpowers/specs/2026-05-23-idle-gpu-weight-ram-offload-design.md`
+- Backend helper patterns: `src/common/gguf_loader.{h,cpp}`
+- Transformer component: `src/transformer/tts_transformer.{h,cpp}`
+- Vocoder component: `src/decoder/audio_tokenizer_decoder.{h,cpp}`
+- Pipeline lifecycle: `src/pipeline/qwen3_tts.{h,cpp}`
+
+## File Structure
+
+- Create `src/common/gpu_offload_policy.h`: policy struct and parser declaration.
+- Create `src/common/gpu_offload_policy.cpp`: parse `QWEN3_TTS_GPU_OFFLOAD_IDLE_SECS`, low-memory precedence, invalid/negative handling.
+- Create `src/common/weight_residency.h`: residency enum, host tensor store types, backend eligibility declaration, tensor download/upload declarations.
+- Create `src/common/weight_residency.cpp`: reusable tensor copy, transactional upload, host-store cleanup, CUDA/Vulkan backend detection.
+- Modify `CMakeLists.txt`: add new common sources and new tests.
+- Create `tests/test_gpu_offload_policy.cpp`: standalone parser tests with no model files.
+- Create `tests/test_weight_residency.cpp`: standalone GGML tensor store/reload spike using CPU backend and an optional GPU backend branch when one is available at runtime.
+- Modify `src/transformer/tts_transformer.{h,cpp}`: transformer residency state, host copies, component offload/reload API.
+- Modify `src/decoder/audio_tokenizer_decoder.{h,cpp}`: decoder residency state, host copies, component offload/reload API.
+- Modify `src/pipeline/qwen3_tts.{h,cpp}`: lifecycle mutex, idle worker, operation guard, public path residency guard, low-memory precedence.
+- Modify `README.md`: document `QWEN3_TTS_GPU_OFFLOAD_IDLE_SECS`, precedence with `QWEN3_TTS_LOW_MEM`, and validation notes.
+
+## Task 1: Add Offload Policy Parser
+
+**Files:**
+- Create: `src/common/gpu_offload_policy.h`
+- Create: `src/common/gpu_offload_policy.cpp`
+- Create: `tests/test_gpu_offload_policy.cpp`
+- Modify: `CMakeLists.txt`
+
+- [ ] **Step 1: Write failing policy parser tests**
+
+Add `tests/test_gpu_offload_policy.cpp`:
+
+```cpp
+#include "common/gpu_offload_policy.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+static int fail(const char * msg) {
+    std::fprintf(stderr, "FAIL: %s\n", msg);
+    return 1;
+}
+
+static int expect_policy(const char * env_value, bool low_mem,
+                         bool expected_enabled, int expected_secs,
+                         const char * expected_reason_substr) {
+    qwen3_tts::gpu_offload_policy p =
+        qwen3_tts::parse_gpu_offload_policy(env_value, low_mem);
+    if (p.enabled != expected_enabled) return fail("enabled mismatch");
+    if (p.idle_secs != expected_secs) return fail("idle_secs mismatch");
+    if (expected_reason_substr &&
+        p.reason.find(expected_reason_substr) == std::string::npos) {
+        return fail("reason mismatch");
+    }
+    return 0;
+}
+
+int main() {
+    if (expect_policy(nullptr, false, false, 0, "unset") != 0) return 1;
+    if (expect_policy("", false, false, 0, "unset") != 0) return 1;
+    if (expect_policy("0", false, false, 0, "disabled") != 0) return 1;
+    if (expect_policy("15", false, true, 15, "enabled") != 0) return 1;
+    if (expect_policy("-2", false, false, 0, "invalid") != 0) return 1;
+    if (expect_policy("abc", false, false, 0, "invalid") != 0) return 1;
+    if (expect_policy("15", true, false, 0, "QWEN3_TTS_LOW_MEM") != 0) return 1;
+    std::printf("gpu_offload_policy tests passed\n");
+    return 0;
+}
+```
+
+- [ ] **Step 2: Register test target and run to verify it fails**
+
+Modify `CMakeLists.txt` temporarily enough to add:
+
+```cmake
+add_executable(test_gpu_offload_policy
+    tests/test_gpu_offload_policy.cpp
+)
+target_link_libraries(test_gpu_offload_policy PRIVATE
+    qwen3_tts_common
+)
+add_test(NAME gpu_offload_policy_test
+    COMMAND test_gpu_offload_policy
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+```
+
+Run:
+
+```bash
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
+cmake --build build --target test_gpu_offload_policy -j4
+```
+
+Expected: build fails because `common/gpu_offload_policy.h` does not exist.
+
+- [ ] **Step 3: Implement minimal policy parser**
+
+Create `src/common/gpu_offload_policy.h`:
+
+```cpp
+#pragma once
+
+#include <string>
+
+namespace qwen3_tts {
+
+struct gpu_offload_policy {
+    bool enabled = false;
+    int idle_secs = 0;
+    std::string reason;
+};
+
+gpu_offload_policy parse_gpu_offload_policy(const char * idle_env, bool low_mem_enabled);
+
+} // namespace qwen3_tts
+```
+
+Create `src/common/gpu_offload_policy.cpp`:
+
+```cpp
+#include "common/gpu_offload_policy.h"
+
+#include <cerrno>
+#include <climits>
+#include <cstdlib>
+
+namespace qwen3_tts {
+
+gpu_offload_policy parse_gpu_offload_policy(const char * idle_env, bool low_mem_enabled) {
+    gpu_offload_policy out;
+    if (low_mem_enabled) {
+        out.reason = "disabled because QWEN3_TTS_LOW_MEM is enabled";
+        return out;
+    }
+    if (!idle_env || idle_env[0] == '\0') {
+        out.reason = "unset";
+        return out;
+    }
+
+    errno = 0;
+    char * end = nullptr;
+    long parsed = std::strtol(idle_env, &end, 10);
+    if (errno != 0 || end == idle_env || *end != '\0' || parsed < 0 || parsed > INT_MAX) {
+        out.reason = "invalid value, disabled";
+        return out;
+    }
+    if (parsed == 0) {
+        out.reason = "disabled";
+        return out;
+    }
+
+    out.enabled = true;
+    out.idle_secs = (int) parsed;
+    out.reason = "enabled";
+    return out;
+}
+
+} // namespace qwen3_tts
+```
+
+Add `src/common/gpu_offload_policy.cpp` to `COMMON_SOURCES` in `CMakeLists.txt`.
+Add `src/common/gpu_offload_policy.h` to the installed header list.
+
+- [ ] **Step 4: Run parser test**
+
+Run:
+
+```bash
+cmake --build build --target test_gpu_offload_policy -j4
+./build/test_gpu_offload_policy
+```
+
+Expected: `gpu_offload_policy tests passed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CMakeLists.txt src/common/gpu_offload_policy.* tests/test_gpu_offload_policy.cpp
+git commit -m "feat(offload): add idle GPU offload policy parser"
+```
+
+## Task 2: Add Reusable Weight Residency Helpers
+
+**Files:**
+- Create: `src/common/weight_residency.h`
+- Create: `src/common/weight_residency.cpp`
+- Create: `tests/test_weight_residency.cpp`
+- Modify: `CMakeLists.txt`
+
+- [ ] **Step 1: Write failing tensor residency test**
+
+Create `tests/test_weight_residency.cpp` with a CPU backend spike. This verifies that GGML tensor metadata can be reused after freeing and reallocating a backend buffer. Include an optional GPU backend branch in the same test when one is available at runtime, but keep CPU as the always-runnable baseline.
+
+```cpp
+#include "common/weight_residency.h"
+
+#include "ggml.h"
+#include "ggml-backend.h"
+
+#include <cstdio>
+#include <cstring>
+#include <map>
+#include <string>
+#include <vector>
+
+static int fail(const char * msg) {
+    std::fprintf(stderr, "FAIL: %s\n", msg);
+    return 1;
+}
+
+static int run_backend_roundtrip(enum ggml_backend_dev_type type) {
+    ggml_backend_t backend = ggml_backend_init_by_type(type, nullptr);
+    if (!backend) return 0; // optional backend unavailable
+
+    ggml_init_params params = {
+        /*.mem_size   =*/ ggml_tensor_overhead() * 2,
+        /*.mem_buffer =*/ nullptr,
+        /*.no_alloc   =*/ true,
+    };
+    ggml_context * ctx = ggml_init(params);
+    if (!ctx) return fail("ggml_init failed");
+
+    ggml_tensor * t = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, 4);
+    ggml_set_name(t, "test.weight");
+    std::map<std::string, ggml_tensor *> tensors;
+    tensors["test.weight"] = t;
+
+    ggml_backend_buffer_t buffer = ggml_backend_alloc_ctx_tensors(ctx, backend);
+    if (!buffer) return fail("alloc buffer failed");
+
+    float input[4] = {1.0f, 2.0f, 3.0f, 4.0f};
+    ggml_backend_tensor_set(t, input, 0, sizeof(input));
+
+    qwen3_tts::host_tensor_store store;
+    std::string error;
+    if (!qwen3_tts::download_tensors_to_host(tensors, store, error)) {
+        return fail(error.c_str());
+    }
+
+    ggml_backend_buffer_free(buffer);
+    buffer = nullptr;
+
+    if (!qwen3_tts::upload_tensors_from_host(ctx, tensors, backend, store, buffer, error)) {
+        return fail(error.c_str());
+    }
+
+    float output[4] = {};
+    ggml_backend_tensor_get(t, output, 0, sizeof(output));
+    for (int i = 0; i < 4; ++i) {
+        if (output[i] != input[i]) return fail("roundtrip mismatch");
+    }
+
+    ggml_backend_buffer_free(buffer);
+    ggml_free(ctx);
+    ggml_backend_free(backend);
+    return 0;
+}
+
+int main() {
+    if (run_backend_roundtrip(GGML_BACKEND_DEVICE_TYPE_CPU) != 0) return 1;
+    (void) run_backend_roundtrip(GGML_BACKEND_DEVICE_TYPE_GPU);
+    std::printf("weight_residency tests passed\n");
+    return 0;
+}
+```
+
+- [ ] **Step 2: Register test target and run to verify it fails**
+
+Add `test_weight_residency` to `CMakeLists.txt`, linked with `qwen3_tts_common`.
+
+Run:
+
+```bash
+cmake --build build --target test_weight_residency -j4
+```
+
+Expected: build fails because `common/weight_residency.h` does not exist.
+
+- [ ] **Step 3: Implement helper types and functions**
+
+Create `src/common/weight_residency.h`:
+
+```cpp
+#pragma once
+
+#include "ggml.h"
+#include "ggml-backend.h"
+
+#include <cstdint>
+#include <cstddef>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace qwen3_tts {
+
+enum class weight_residency {
+    Unloaded,
+    GpuResident,
+    RamResident,
+};
+
+struct host_tensor_copy {
+    std::string name;
+    std::vector<uint8_t> bytes;
+};
+
+struct host_tensor_store {
+    std::vector<host_tensor_copy> tensors;
+    size_t total_bytes = 0;
+    void clear();
+};
+
+bool backend_is_cuda_or_vulkan(ggml_backend_t backend);
+bool download_tensors_to_host(const std::map<std::string, ggml_tensor *> & tensors,
+                              host_tensor_store & out,
+                              std::string & error);
+bool upload_tensors_from_host(ggml_context * ctx,
+                              const std::map<std::string, ggml_tensor *> & tensors,
+                              ggml_backend_t backend,
+                              const host_tensor_store & store,
+                              ggml_backend_buffer_t & buffer,
+                              std::string & error);
+
+} // namespace qwen3_tts
+```
+
+Create `src/common/weight_residency.cpp` with:
+
+- `backend_is_cuda_or_vulkan()`: inspect `ggml_backend_get_device()`, `ggml_backend_dev_backend_reg()`, and `ggml_backend_reg_name()`, accepting `CUDA` and `Vulkan`.
+- `download_tensors_to_host()`: clear destination, iterate tensor map, copy `ggml_nbytes(tensor)` with `ggml_backend_tensor_get()`, track total bytes.
+- `upload_tensors_from_host()`: allocate a new buffer with `ggml_backend_alloc_ctx_tensors(ctx, backend)`, upload all copies by name, and free the new buffer on any partial failure.
+- `host_tensor_store::clear()`: clear vector and reset bytes.
+
+Add `src/common/weight_residency.cpp` to `COMMON_SOURCES`.
+Add `src/common/weight_residency.h` to the installed header list.
+
+- [ ] **Step 4: Run tensor residency test**
+
+Run:
+
+```bash
+cmake --build build --target test_weight_residency -j4
+./build/test_weight_residency
+```
+
+Expected: `weight_residency tests passed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CMakeLists.txt src/common/weight_residency.* tests/test_weight_residency.cpp
+git commit -m "feat(offload): add weight residency helpers"
+```
+
+## Task 3: Add Transformer Component Offload API
+
+**Files:**
+- Modify: `src/transformer/tts_transformer.h`
+- Modify: `src/transformer/tts_transformer.cpp`
+- Modify: `tests/test_transformer.cpp`
+
+- [ ] **Step 1: Write failing transformer API coverage**
+
+In `tests/test_transformer.cpp`, add coverage near the existing model-load checks:
+
+```cpp
+if (transformer.is_ram_offloaded()) {
+    fprintf(stderr, "  FAIL: transformer should not start RAM-offloaded\n");
+    return 1;
+}
+if (transformer.can_offload_to_ram()) {
+    std::string offload_error;
+    if (!transformer.offload_weights_to_ram(offload_error)) {
+        fprintf(stderr, "  FAIL: transformer offload failed: %s\n", offload_error.c_str());
+        return 1;
+    }
+    if (!transformer.is_ram_offloaded()) {
+        fprintf(stderr, "  FAIL: transformer did not enter RAM-resident state\n");
+        return 1;
+    }
+    if (!transformer.reload_weights_from_ram(offload_error)) {
+        fprintf(stderr, "  FAIL: transformer reload failed: %s\n", offload_error.c_str());
+        return 1;
+    }
+}
+```
+
+This test only performs the full offload/reload path when the selected backend is CUDA/Vulkan. On CPU/Metal it verifies the methods exist and the component does not falsely report RAM-offloaded state.
+
+- [ ] **Step 2: Run test target to verify it fails**
+
+Run:
+
+```bash
+cmake --build build --target test_transformer -j4
+```
+
+Expected: build fails because transformer offload methods do not exist.
+
+- [ ] **Step 3: Add transformer state and declarations**
+
+In `src/transformer/tts_transformer.h`, include `common/weight_residency.h` and add public methods:
+
+```cpp
+bool can_offload_to_ram() const;
+bool offload_weights_to_ram(std::string & error);
+bool reload_weights_from_ram(std::string & error);
+bool is_ram_offloaded() const;
+size_t ram_offloaded_bytes() const;
+```
+
+Add private/model fields:
+
+```cpp
+weight_residency residency = weight_residency::Unloaded;
+host_tensor_store host_weights;
+```
+
+- [ ] **Step 4: Implement transformer offload/reload**
+
+In `TTSTransformer::load_tensor_data()`, after successful upload, set:
+
+```cpp
+model_.host_weights.clear();
+model_.residency = weight_residency::GpuResident;
+```
+
+In `free_transformer_model()`, clear host weights and set `Unloaded`.
+
+Implement:
+
+```cpp
+bool TTSTransformer::can_offload_to_ram() const {
+    return model_.residency == weight_residency::GpuResident &&
+           model_.buffer != nullptr &&
+           backend_is_cuda_or_vulkan(state_.backend);
+}
+```
+
+`offload_weights_to_ram()` should:
+
+- Return true immediately if already `RamResident`.
+- Return false with error if not GPU-resident.
+- Free talker and code predictor KV caches.
+- Reset scheduler if present.
+- Download `model_.tensors` into `model_.host_weights`.
+- Free `model_.buffer`.
+- Set `model_.residency = weight_residency::RamResident`.
+
+`reload_weights_from_ram()` should:
+
+- Return true immediately if already `GpuResident`.
+- Allocate/upload transactionally through `upload_tensors_from_host()`.
+- On success set `GpuResident` and clear host copies.
+- On failure keep `RamResident`.
+
+- [ ] **Step 5: Run transformer target**
+
+Run:
+
+```bash
+cmake --build build --target test_transformer -j4
+```
+
+Expected: build succeeds. If model/reference files are available, run:
+
+```bash
+./build/test_transformer
+```
+
+Expected: existing transformer checks pass; offload path is skipped unless CUDA/Vulkan is active.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/transformer/tts_transformer.* tests/test_transformer.cpp
+git commit -m "feat(offload): add transformer RAM residency API"
+```
+
+## Task 4: Add Decoder Component Offload API
+
+**Files:**
+- Modify: `src/decoder/audio_tokenizer_decoder.h`
+- Modify: `src/decoder/audio_tokenizer_decoder.cpp`
+- Modify: `tests/test_decoder.cpp`
+
+- [ ] **Step 1: Write failing decoder API coverage**
+
+In `tests/test_decoder.cpp`, after `decoder.load_model(tokenizer_path)` succeeds, add:
+
+```cpp
+if (decoder.is_ram_offloaded()) {
+    fprintf(stderr, "  FAIL: decoder should not start RAM-offloaded\n");
+    return 1;
+}
+if (decoder.can_offload_to_ram()) {
+    std::string offload_error;
+    if (!decoder.offload_weights_to_ram(offload_error)) {
+        fprintf(stderr, "  FAIL: decoder offload failed: %s\n", offload_error.c_str());
+        return 1;
+    }
+    if (!decoder.is_ram_offloaded()) {
+        fprintf(stderr, "  FAIL: decoder did not enter RAM-resident state\n");
+        return 1;
+    }
+    if (!decoder.reload_weights_from_ram(offload_error)) {
+        fprintf(stderr, "  FAIL: decoder reload failed: %s\n", offload_error.c_str());
+        return 1;
+    }
+}
+```
+
+- [ ] **Step 2: Run test target to verify it fails**
+
+Run:
+
+```bash
+cmake --build build --target test_decoder -j4
+```
+
+Expected: build fails because decoder offload methods do not exist.
+
+- [ ] **Step 3: Add decoder state and declarations**
+
+In `src/decoder/audio_tokenizer_decoder.h`, include `common/weight_residency.h`, add the same public API as transformer, and add `weight_residency residency` plus `host_tensor_store host_weights` to `audio_decoder_model`.
+
+- [ ] **Step 4: Implement decoder offload/reload**
+
+In `AudioTokenizerDecoder::load_model()`, after tensor load and codebook normalization, set residency `GpuResident` and clear host copies.
+
+In `free_audio_decoder_model()`, clear host copies and set `Unloaded`.
+
+Implement component methods analogous to transformer:
+
+- `can_offload_to_ram()` requires CUDA/Vulkan, `GpuResident`, and non-null `model_.buffer`.
+- `offload_weights_to_ram()` resets scheduler if present, downloads tensors, frees `model_.buffer`, marks `RamResident`.
+- `reload_weights_from_ram()` uploads transactionally, clears host copies on success, remains `RamResident` on failure.
+
+- [ ] **Step 5: Run decoder target**
+
+Run:
+
+```bash
+cmake --build build --target test_decoder -j4
+```
+
+Expected: build succeeds. If tokenizer model and reference codes are available, run:
+
+```bash
+./build/test_decoder
+```
+
+Expected: existing decoder checks pass; offload path is skipped unless CUDA/Vulkan is active.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/decoder/audio_tokenizer_decoder.* tests/test_decoder.cpp
+git commit -m "feat(offload): add decoder RAM residency API"
+```
+
+## Task 5: Add Engine Lifecycle Guard And Idle Worker
+
+**Files:**
+- Modify: `src/pipeline/qwen3_tts.h`
+- Modify: `src/pipeline/qwen3_tts.cpp`
+
+- [ ] **Step 1: Add lifecycle fields and helper declarations**
+
+In `src/pipeline/qwen3_tts.h`, include `<condition_variable>`, `<mutex>`, `<thread>`, and `<cstdint>`.
+
+Add private fields:
+
+```cpp
+std::mutex lifecycle_mutex_;
+std::condition_variable idle_cv_;
+std::thread idle_worker_;
+bool idle_worker_shutdown_ = false;
+bool operation_active_ = false;
+uint64_t idle_generation_ = 0;
+int gpu_offload_idle_secs_ = 0;
+bool gpu_idle_offload_enabled_ = false;
+```
+
+Add private helper declarations:
+
+```cpp
+enum class residency_component : uint32_t {
+    none = 0,
+    transformer = 1u << 0,
+    decoder = 1u << 1,
+};
+
+bool ensure_runtime_resident_locked(uint32_t required, std::string & error);
+void finish_guarded_operation_locked();
+void arm_idle_worker_locked();
+void start_idle_worker_locked();
+void stop_idle_worker();
+void idle_worker_main();
+void offload_idle_components_locked();
+```
+
+Add public C++-only test/diagnostic declarations near the other public methods.
+Do not expose these through `qwen3tts_c_api.h` or the Python binding:
+
+```cpp
+bool force_transformer_offload_for_test(std::string & error);
+bool transformer_ram_offloaded_for_test() const;
+bool force_idle_offload_once_for_test(std::string & error);
+```
+
+- [ ] **Step 2: Implement worker shutdown before teardown**
+
+Change `Qwen3TTS::~Qwen3TTS()` from default to:
+
+```cpp
+Qwen3TTS::~Qwen3TTS() {
+    stop_idle_worker();
+}
+```
+
+At the start of `load_models()`, call `stop_idle_worker()` before unloading/replacing existing components.
+
+`stop_idle_worker()` must set shutdown, increment generation, notify, unlock, and join if joinable.
+
+- [ ] **Step 3: Parse and log policy**
+
+In `load_models()`, after computing `low_mem_mode_`, parse:
+
+```cpp
+auto policy = parse_gpu_offload_policy(std::getenv("QWEN3_TTS_GPU_OFFLOAD_IDLE_SECS"),
+                                       low_mem_mode_);
+gpu_idle_offload_enabled_ = policy.enabled;
+gpu_offload_idle_secs_ = policy.idle_secs;
+fprintf(stderr, "  GPU idle RAM offload: %s (%s)\n",
+        gpu_idle_offload_enabled_ ? "enabled" : "disabled",
+        policy.reason.c_str());
+```
+
+After loading initial components, start the worker when enabled.
+
+- [ ] **Step 4: Implement guarded operation helper**
+
+`ensure_runtime_resident_locked(required, error)` should:
+
+- Increment `idle_generation_` to invalidate pending timers.
+- If a required component is RAM-resident, call its reload method.
+- Set `operation_active_ = true` only after required reloads have succeeded.
+- Return false and leave a clear error if reload fails.
+
+`finish_guarded_operation_locked()` should:
+
+- Set `operation_active_ = false`.
+- Increment `idle_generation_`.
+- Notify the idle worker if enabled.
+
+- [ ] **Step 5: Implement idle worker**
+
+`idle_worker_main()` should loop:
+
+1. Wait until enabled, not active, and not shutdown.
+2. Capture current generation.
+3. Wait for `gpu_offload_idle_secs_`.
+4. Recheck shutdown, active state, and generation.
+5. Call `offload_idle_components_locked()`.
+
+`offload_idle_components_locked()` should call transformer/decoder offload only when loaded and `can_offload_to_ram()` returns true. Log bytes copied and warnings on failure. If idle RAM offload is enabled but a loaded component is ineligible because the backend is CPU, Metal, or unknown, log that ineligibility once per component/backend so users understand why no VRAM is released.
+
+- [ ] **Step 6: Add deterministic test/diagnostic hooks**
+
+Add C++-only helpers on `Qwen3TTS`; do not expose them through the C API or Python binding:
+
+```cpp
+bool Qwen3TTS::force_transformer_offload_for_test(std::string & error);
+bool Qwen3TTS::transformer_ram_offloaded_for_test() const;
+bool Qwen3TTS::force_idle_offload_once_for_test(std::string & error);
+```
+
+`force_transformer_offload_for_test()` should lock the lifecycle mutex and call
+`transformer_.offload_weights_to_ram(error)` without requiring CUDA/Vulkan
+eligibility. This is for deterministic residency guard tests; production idle
+worker logic must still use `can_offload_to_ram()` so CPU/Metal do not offload
+in normal operation.
+
+`force_idle_offload_once_for_test()` should lock the lifecycle mutex, verify no
+operation is active, and call the same internal offload path as the worker with
+an explicit test flag that bypasses backend eligibility. This makes worker
+teardown and guard tests deterministic on CPU builds.
+
+- [ ] **Step 7: Build**
+
+Run:
+
+```bash
+cmake --build build --target qwen3_tts -j4
+cmake --build build --target qwen3tts_shared -j4
+```
+
+Expected: both targets build.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/pipeline/qwen3_tts.*
+git commit -m "feat(offload): add engine idle offload lifecycle"
+```
+
+## Task 6: Guard Public Engine Paths Without Deadlocks
+
+**Files:**
+- Modify: `src/pipeline/qwen3_tts.h`
+- Modify: `src/pipeline/qwen3_tts.cpp`
+- Modify: `tests/test_codec_encoder.cpp` only if build fallout requires it
+
+- [ ] **Step 1: Refactor public methods to avoid nested locks**
+
+Public methods that call other public overloads must not acquire the lifecycle mutex twice. Introduce private unlocked helpers where needed:
+
+```cpp
+tts_result synthesize_with_voice_samples_unlocked(const std::string & text,
+                                                  const float * ref_samples,
+                                                  int32_t n_ref_samples,
+                                                  const tts_params & params);
+tts_result synthesize_internal_unlocked(const std::string & text,
+                                        const float * speaker_embedding,
+                                        const tts_params & params,
+                                        tts_result & result,
+                                        const int32_t * ref_codes = nullptr,
+                                        int32_t n_ref_frames = 0);
+bool extract_speaker_embedding_unlocked(const float * ref_samples,
+                                        int32_t n_ref_samples,
+                                        std::vector<float> & embedding,
+                                        const tts_params & params);
+```
+
+At minimum, avoid deadlock in:
+
+- `synthesize_with_voice(const std::string & text, const std::string & reference_audio, const tts_params & params)` calling the samples overload.
+- `synthesize()` calling `synthesize_internal()`.
+- `synthesize_with_embedding()` calling `synthesize_internal()`.
+
+- [ ] **Step 2: Guard synthesis paths**
+
+At the start of each public synthesis path, hold the lifecycle mutex for the full operation and require:
+
+- `synthesize()`: transformer plus decoder if decoder is already loaded; decoder is reloaded/lazy-loaded later under the same lock.
+- `synthesize_with_voice()` and ICL paths: transformer, plus lazy encoders as needed; first-pass offload only reloads transformer/decoder.
+- `synthesize_with_embedding()`: transformer plus decoder.
+
+After operation completion or early return, call `finish_guarded_operation_locked()` via RAII to ensure the idle worker is armed after failures too.
+
+- [ ] **Step 3: Guard speaker embedding extraction**
+
+Wrap public `extract_speaker_embedding()` with the lifecycle mutex and operation
+guard. It does not need transformer/decoder residency in the first pass, but it
+must mark the engine active so the idle worker cannot offload transformer or
+decoder while lazy speaker encoder loading/compute is in progress.
+
+The public method should call
+`extract_speaker_embedding_unlocked(ref_samples, n_ref_samples, embedding, params)`
+after the guard is established.
+
+- [ ] **Step 4: Guard non-synthesis tensor path**
+
+Wrap `get_speaker_embedding()` with the lifecycle mutex and `ensure_runtime_resident_locked(transformer, error_msg_)` before calling `transformer_.get_codec_embedding_row()`.
+
+Do not reload for metadata-only accessors:
+
+- `get_model_type()`
+- `get_model_size()`
+- `has_speaker_encoder()`
+- `get_speaker_names()`
+- `get_speaker_ids()`
+- `get_speaker_dialects()`
+- `get_speaker_id()`
+- `is_loaded()`
+
+- [ ] **Step 5: Build all public API targets**
+
+Run:
+
+```bash
+cmake --build build --target qwen3-tts-cli qwen3tts_shared -j4
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pipeline/qwen3_tts.*
+git commit -m "feat(offload): guard engine tensor access paths"
+```
+
+## Task 7: Add Integration Coverage For Guard And Worker Behavior
+
+**Files:**
+- Create: `tests/test_pipeline_offload_lifecycle.cpp`
+- Modify: `CMakeLists.txt`
+
+- [ ] **Step 1: Write model-dependent integration test**
+
+Create `tests/test_pipeline_offload_lifecycle.cpp`. Keep it model-dependent like existing component tests and skip cleanly when model files are absent.
+
+Test shape:
+
+```cpp
+#include "pipeline/qwen3_tts.h"
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <thread>
+#include <vector>
+
+static void set_test_env(const char * name, const char * value) {
+#ifdef _WIN32
+    _putenv_s(name, value);
+#else
+    setenv(name, value, 1);
+#endif
+}
+
+int main() {
+    set_test_env("QWEN3_TTS_GPU_OFFLOAD_IDLE_SECS", "1");
+    set_test_env("QWEN3_TTS_BACKEND", "cpu");
+
+    qwen3_tts::Qwen3TTS tts;
+    if (!tts.load_models("models")) {
+        std::fprintf(stderr, "SKIP: models unavailable: %s\n", tts.get_error().c_str());
+        return 0;
+    }
+
+    // CPU backend should remain functional and should not offload.
+    auto names = tts.get_speaker_names();
+
+    qwen3_tts::tts_params params;
+    params.max_audio_tokens = 1;
+    auto result = tts.synthesize("test", params);
+    if (!result.success) {
+        std::fprintf(stderr, "FAIL: synthesize failed: %s\n", result.error_msg.c_str());
+        return 1;
+    }
+
+    // Force an offload through the deterministic test hook, then verify a
+    // public non-synthesis tensor accessor reloads before reading tensors.
+    if (!names.empty()) {
+        std::string err;
+        if (!tts.force_transformer_offload_for_test(err)) {
+            std::fprintf(stderr, "FAIL: forced transformer offload failed: %s\n", err.c_str());
+            return 1;
+        }
+        if (!tts.transformer_ram_offloaded_for_test()) {
+            std::fprintf(stderr, "FAIL: transformer did not report RAM-offloaded\n");
+            return 1;
+        }
+        std::vector<float> embedding;
+        if (!tts.get_speaker_embedding(names[0], embedding)) {
+            std::fprintf(stderr, "FAIL: get_speaker_embedding failed after forced offload: %s\n",
+                         tts.get_error().c_str());
+            return 1;
+        }
+        if (embedding.empty() || tts.transformer_ram_offloaded_for_test()) {
+            std::fprintf(stderr, "FAIL: get_speaker_embedding did not reload transformer\n");
+            return 1;
+        }
+    }
+
+    // Force the worker offload path and ensure load_models() can stop worker
+    // state and reload models without racing teardown.
+    std::string err;
+    if (!tts.force_idle_offload_once_for_test(err)) {
+        std::fprintf(stderr, "FAIL: forced idle offload failed: %s\n", err.c_str());
+        return 1;
+    }
+    if (!tts.transformer_ram_offloaded_for_test()) {
+        std::fprintf(stderr, "FAIL: forced idle offload did not offload transformer\n");
+        return 1;
+    }
+    if (!tts.load_models("models")) {
+        std::fprintf(stderr, "FAIL: reload after forced idle offload failed: %s\n",
+                     tts.get_error().c_str());
+        return 1;
+    }
+
+    std::printf("pipeline offload lifecycle test passed\n");
+    return 0;
+}
+```
+
+This test verifies policy plumbing, CPU no-op behavior, deterministic forced
+offload/reload, guarded public tensor access, and `load_models()` worker
+shutdown with the feature configured. CUDA/Vulkan device-memory release is
+validated manually in Task 10.
+
+- [ ] **Step 2: Register and build test**
+
+Add target:
+
+```cmake
+add_executable(test_pipeline_offload_lifecycle
+    tests/test_pipeline_offload_lifecycle.cpp
+)
+target_link_libraries(test_pipeline_offload_lifecycle PRIVATE
+    qwen3_tts
+    Threads::Threads
+)
+add_test(NAME pipeline_offload_lifecycle_test
+    COMMAND test_pipeline_offload_lifecycle
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+```
+
+Run:
+
+```bash
+cmake --build build --target test_pipeline_offload_lifecycle -j4
+./build/test_pipeline_offload_lifecycle
+```
+
+Expected: either `pipeline offload lifecycle test passed` when models exist or output beginning with `SKIP: models unavailable` with exit code 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CMakeLists.txt tests/test_pipeline_offload_lifecycle.cpp
+git commit -m "test(offload): cover engine lifecycle guard"
+```
+
+## Task 8: Update Documentation
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Add runtime variable documentation**
+
+In README runtime environment variables, add:
+
+```markdown
+| `QWEN3_TTS_GPU_OFFLOAD_IDLE_SECS` | `0` | CUDA/Vulkan only. Positive values enable idle RAM offload after N idle seconds. Disabled when `QWEN3_TTS_LOW_MEM=1`. |
+```
+
+- [ ] **Step 2: Add backend notes**
+
+Near Backend Selection or Memory Management, add a short note:
+
+```markdown
+Idle GPU RAM offload is intended for long-lived CUDA/Vulkan processes that want
+to release VRAM between requests. It copies weights to host RAM only after the
+idle timeout fires, frees GPU weight buffers, and reloads from RAM on the next
+tensor-using request. It does not stream layers during inference and is disabled
+for Metal/CPU backends.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: document idle GPU RAM offload"
+```
+
+## Task 9: Full Local Verification
+
+**Files:**
+- No source changes expected.
+
+- [ ] **Step 1: Configure build**
+
+Run:
+
+```bash
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
+```
+
+Expected: configure completes.
+
+- [ ] **Step 2: Build all core/test targets**
+
+Run:
+
+```bash
+cmake --build build -j4
+```
+
+Expected: build completes.
+
+- [ ] **Step 3: Run model-independent tests**
+
+Run:
+
+```bash
+./build/test_gpu_offload_policy
+./build/test_weight_residency
+```
+
+Expected: both print passed messages.
+
+- [ ] **Step 4: Run available model-dependent tests**
+
+Run as available:
+
+```bash
+./build/test_transformer
+./build/test_decoder
+./build/test_pipeline_offload_lifecycle
+```
+
+Expected: tests pass when model files are present; `test_pipeline_offload_lifecycle` may skip if model files are absent.
+
+- [ ] **Step 5: Address verification fallout in the owning task**
+
+If verification reveals a bug, return to the task that introduced that code,
+make the smallest fix there, rerun that task's tests, and commit with that
+task's file-specific `git add` command. Do not make an unscoped verification
+commit.
+
+## Task 10: Manual CUDA/Vulkan Validation
+
+**Files:**
+- No source changes expected unless validation reveals a bug.
+
+- [ ] **Step 1: CUDA VRAM validation**
+
+With a CUDA GGML build and model files present, run:
+
+```bash
+QWEN3_TTS_BACKEND=cuda QWEN3_TTS_GPU_OFFLOAD_IDLE_SECS=2 \
+  ./build/qwen3-tts-cli -m models -t "short test" -o /tmp/qwen-offload-test.wav
+```
+
+In another terminal, observe:
+
+```bash
+nvidia-smi
+```
+
+Expected:
+
+- VRAM rises during load/inference.
+- After about 2 idle seconds in a long-lived process, logs show idle offload.
+- VRAM drops after offload.
+- A subsequent tensor-using request logs reload from RAM and succeeds.
+
+For CLI, the process may exit before idle offload matters. Prefer the Python server or a tiny local harness that keeps `Qwen3TTS` alive across two requests.
+
+- [ ] **Step 2: Vulkan validation**
+
+With a Vulkan GGML build, run a long-lived server or harness:
+
+```bash
+QWEN3_TTS_BACKEND=auto QWEN3_TTS_GPU_OFFLOAD_IDLE_SECS=2 \
+  python server/main.py
+```
+
+Send a speech request, wait beyond the timeout, then send another request.
+
+Expected:
+
+- Logs identify a Vulkan backend for offloadable components.
+- Logs show idle offload and RAM reload.
+- The second request succeeds.
+
+- [ ] **Step 3: Low-memory precedence validation**
+
+Run:
+
+```bash
+QWEN3_TTS_LOW_MEM=1 QWEN3_TTS_GPU_OFFLOAD_IDLE_SECS=2 \
+  ./build/qwen3-tts-cli -m models -t "short test" -o /tmp/qwen-lowmem-test.wav
+```
+
+Expected: startup logs say idle RAM offload is disabled because low-memory mode is enabled.
+
+- [ ] **Step 4: Address GPU validation fallout in the owning task**
+
+If CUDA/Vulkan validation reveals a bug, return to the component or engine task
+that owns the failure, make the smallest fix there, rerun relevant local tests
+and GPU validation, then commit with a file-specific `git add` command.
+
+## Final Handoff Checklist
+
+- [ ] `git status --short` is clean.
+- [ ] `git log --oneline -5` shows task commits.
+- [ ] Report which tests ran and which GPU manual validations were available.
+- [ ] If CUDA/Vulkan hardware was unavailable, explicitly state that GPU VRAM release still needs hardware validation.

--- a/docs/superpowers/specs/2026-05-23-idle-gpu-weight-ram-offload-design.md
+++ b/docs/superpowers/specs/2026-05-23-idle-gpu-weight-ram-offload-design.md
@@ -1,0 +1,274 @@
+# Idle GPU Weight RAM Offload Design
+
+## Summary
+
+Add an engine-core idle offload feature for CUDA and Vulkan backends. When a
+long-lived `Qwen3TTS` engine has been idle for a configured timeout, it copies
+GPU-resident model weights into host RAM, frees the component GPU weight
+buffers, and marks those components as RAM-resident. The next synthesis request
+uploads the host copies back to GPU before inference.
+
+The feature is disabled by default and is distinct from `QWEN3_TTS_LOW_MEM`.
+Low-memory mode unloads components and reloads from GGUF files. This feature
+keeps component metadata and host tensor bytes so reload avoids disk reads.
+
+## Goals
+
+- Reduce idle CUDA/Vulkan VRAM usage between requests in long-lived processes.
+- Keep reload faster than disk-based unload/reload by retaining host tensor
+  bytes after offload.
+- Keep active inference RAM usage unchanged by creating host copies only when
+  the idle offload fires.
+- Put the policy in the C++ engine core so CLI, C API, and Python server users
+  can all benefit.
+- Preserve current behavior unless the feature is explicitly enabled.
+
+## Non-Goals
+
+- Layer streaming to fit models larger than available VRAM.
+- Offloading weights during active inference.
+- Metal support in the first version. Apple Silicon unified memory makes RAM vs
+  VRAM behavior less clear, and CUDA/Vulkan are easier to validate.
+- Replacing `QWEN3_TTS_LOW_MEM`.
+- Preserving KV caches or transient compute buffers across idle offload.
+
+## Configuration
+
+Add an environment-driven configuration in the engine core:
+
+- `QWEN3_TTS_GPU_OFFLOAD_IDLE_SECS=0` disables idle RAM offload. This is the
+  default.
+- A positive value enables idle offload after that many idle seconds.
+
+The first implementation can parse this in `Qwen3TTS::load_models()` and store
+it on the engine. Later API-level configuration can be added if consumers need
+non-environment control.
+
+If `QWEN3_TTS_LOW_MEM` and `QWEN3_TTS_GPU_OFFLOAD_IDLE_SECS` are both enabled,
+`QWEN3_TTS_LOW_MEM` takes precedence and idle RAM offload is disabled entirely,
+with a clear startup log. This keeps the two memory policies from fighting over
+the same component lifecycle.
+
+## Residency Model
+
+Each offloadable component tracks a weight residency state:
+
+- `GpuResident`: GGML tensor metadata and backend weight buffer exist, and
+  weights are ready for inference.
+- `RamResident`: GGML tensor metadata exists, the GPU weight buffer has been
+  freed, and host byte copies exist for tensors.
+- `Unloaded`: current full teardown behavior; no usable tensor data is kept.
+
+The first pass should support the large startup-resident components:
+
+- `TTSTransformer`
+- `AudioTokenizerDecoder`
+
+The same interface can later be applied to `AudioTokenizerEncoder` and
+`AudioCodecEncoder`, but those are lazy-loaded and request-specific, so they are
+not required for the initial idle VRAM reduction.
+
+## Component Interface
+
+Each supported component should expose a small explicit API:
+
+- `bool can_offload_to_ram() const`
+- `bool offload_weights_to_ram(std::string & error)`
+- `bool reload_weights_from_ram(std::string & error)`
+- `bool is_ram_offloaded() const`
+
+`can_offload_to_ram()` returns true only when the component is using a CUDA or
+Vulkan backend and is currently GPU-resident. CPU, Metal, and unknown backends
+return false.
+
+The component remains responsible for its own GGML model context, tensor map,
+backend weight buffer, and host copies. `Qwen3TTS` coordinates when to call the
+component methods.
+
+## Residency Guard
+
+Every public engine path that may read model tensors must ensure the target
+component is GPU-resident before touching backend tensors. This includes
+synthesis paths and non-synthesis accessors such as preset speaker embedding
+lookup, which can read `TTSTransformer` codec embedding rows.
+
+Add a shared engine helper such as `ensure_component_resident(component)` or
+`ensure_runtime_resident(required_components)`. Public methods call this helper
+under the lifecycle mutex before invoking component code that uses
+`ggml_backend_tensor_get()`, `ggml_backend_tensor_set()`, or graph compute.
+
+The helper cancels pending idle offload, reloads any `RamResident` required
+component from host RAM, and marks the engine active for the duration of that
+operation. This prevents a path that is not full synthesis from reading tensor
+metadata after the GPU weight buffer has been freed.
+
+Current public paths to guard or explicitly classify:
+
+- `synthesize()`, `synthesize_with_voice()`, and `synthesize_with_embedding()`
+  require residency for the components they use.
+- `extract_speaker_embedding()` requires a residency check if speaker encoder
+  offload is added later. In the first pass, it should still enter the shared
+  lifecycle guard so idle offload cannot race lazy encoder loading.
+- `get_speaker_embedding()` requires `TTSTransformer` residency because it reads
+  a codec embedding tensor row.
+- Metadata-only accessors such as `get_model_type()`, `get_model_size()`,
+  `has_speaker_encoder()`, `get_speaker_names()`, `get_speaker_ids()`,
+  `get_speaker_dialects()`, `get_speaker_id()`, and `is_loaded()` do not need a
+  GPU residency reload because they read config data, not backend tensor data.
+- C API and Python binding methods inherit the behavior of the engine methods
+  they call; they should not implement separate residency policy.
+
+## Offload Flow
+
+When the idle timeout expires, the engine:
+
+1. Locks the engine lifecycle mutex.
+2. Confirms no synthesis call is active and the idle generation is still
+   current.
+3. For each GPU-resident offloadable component, clears transient state that
+   should not survive offload, such as KV cache or scheduler scratch state.
+4. Allocates or resizes a host byte vector for each model tensor using
+   `ggml_nbytes(tensor)`.
+5. Downloads tensor bytes with `ggml_backend_tensor_get()`.
+6. Frees the component's backend weight buffer with
+   `ggml_backend_buffer_free()`.
+7. Keeps GGML tensor metadata, config, tensor maps, and host bytes.
+8. Marks the component `RamResident`.
+
+Offload does not release the shared preferred backend handle unless the
+component is genuinely unloaded or destroyed. Freeing the weight buffer is the
+operation intended to release idle VRAM.
+
+## Reload Flow
+
+At the start of any guarded public operation that needs backend tensors:
+
+1. Lock the engine lifecycle mutex.
+2. Cancel or invalidate any pending idle offload timer generation.
+3. For each `RamResident` component needed by the request, allocate a fresh
+   CUDA/Vulkan backend buffer with `ggml_backend_alloc_ctx_tensors()`.
+4. Upload each host tensor copy with `ggml_backend_tensor_set()`.
+5. Clear the host copies after successful upload to return RAM where possible.
+6. Mark the component `GpuResident`.
+7. Run the operation normally.
+
+Reload should be transactional at the component level. Allocate and upload into
+a new backend buffer, and only transition to `GpuResident` after all tensors
+succeed. If any upload fails, free the partial backend buffer, keep the host
+copies, leave the component `RamResident`, and return a clear error.
+
+The design assumes GGML tensor metadata remains valid after freeing and
+reallocating the backend buffer. If a backend requires the context and tensor
+objects to be rebuilt, the fallback is to rebuild the component GGML context and
+tensors from saved metadata, then upload from the host RAM copies. That fallback
+still avoids rereading tensor bytes from GGUF.
+
+## Idle Worker And Concurrency
+
+`Qwen3TTS` owns the idle policy and synchronization:
+
+- A lifecycle mutex protects request activity, component residency transitions,
+  and idle timer state.
+- A monotonic generation counter invalidates stale timers.
+- Request start cancels or invalidates any pending offload and reloads
+  RAM-resident weights before compute.
+- Request end records `last_used`, marks the engine inactive, and wakes or arms
+  the idle worker.
+- The idle worker waits for the configured timeout, then rechecks the generation
+  and active-request state under the lifecycle mutex before offloading.
+
+The first implementation should hold the lifecycle mutex for the full public
+operation that can access offloadable components. That preserves the current
+effectively serialized behavior and avoids races between compute, tensor
+accessors, and idle offload. If later work wants concurrent requests, it should
+introduce a narrower read/write residency lock separately.
+
+## Idle Worker Lifecycle
+
+The idle worker must have explicit startup and shutdown ownership in `Qwen3TTS`.
+The worker starts only when idle RAM offload is enabled and models are loaded.
+
+`Qwen3TTS::~Qwen3TTS()` and any `load_models()` call that tears down/replaces
+components must first stop the idle worker:
+
+1. Lock the lifecycle mutex.
+2. Set a shutdown flag and increment the idle generation counter.
+3. Notify the worker condition variable.
+4. Unlock and join the worker thread.
+5. Only after the worker has stopped, unload components or release backend
+   buffers.
+
+This prevents the worker from touching GGML contexts, tensor maps, or backend
+buffers after component teardown has begun.
+
+## Error Handling
+
+- If idle offload fails before freeing the GPU buffer, leave the component
+  `GpuResident`, log a warning, and keep the engine usable.
+- If offload fails after some tensors were copied but before the GPU buffer is
+  freed, discard partial host copies and keep the component `GpuResident`.
+- If offload fails after the GPU buffer is freed and rollback is impossible,
+  mark the component `Unloaded` and make the next request fail clearly rather
+  than hiding the problem.
+- If reload from RAM fails at request start, return a synthesis error. Do not
+  silently fall back to disk reload because that would hide correctness bugs and
+  create unpredictable latency.
+- If reload fails after partial upload, free the partial backend buffer, keep the
+  host tensor copies, leave the component `RamResident`, and report the error.
+- CPU, Metal, and unsupported GPU backends should log that idle RAM offload is
+  inactive when the feature is configured.
+
+## Observability
+
+Add concise logs for:
+
+- Feature enabled/disabled and configured timeout.
+- Backend eligibility per component.
+- Idle offload start, success, failure, and bytes copied.
+- Reload start, success, failure, and bytes uploaded.
+
+The existing memory timing fields track process memory. Device-memory
+validation should be done with backend-specific tools such as `nvidia-smi` for
+CUDA and Vulkan memory tooling or backend logs for Vulkan.
+
+## Testing
+
+Add focused tests around state transitions and request behavior:
+
+- CPU backend with offload enabled: no component offloads, synthesis behavior is
+  unchanged.
+- CUDA/Vulkan-capable build: after idle timeout, transformer and vocoder become
+  `RamResident`.
+- Next synthesis after idle offload reloads weights and produces valid,
+  non-silent audio.
+- Non-synthesis tensor accessors, such as preset speaker embedding lookup,
+  reload required RAM-resident weights before reading tensors.
+- Back-to-back requests inside the timeout do not offload.
+- A request racing with timer expiry invalidates the timer and prevents active
+  offload.
+- Forced offload/reload component tests verify state transitions without a full
+  server lifecycle.
+- Worker lifecycle tests verify that `load_models()` and `Qwen3TTS` destruction
+  stop the idle worker before component buffers are freed.
+- Failure-injection tests for tensor download/upload leave the engine in a clear
+  usable or explicit-error state.
+
+Manual validation should include measuring VRAM before load, after inference,
+after idle offload, and after reload on CUDA. Vulkan validation can use available
+backend memory logs or platform tools.
+
+## Acceptance Criteria
+
+- With `QWEN3_TTS_GPU_OFFLOAD_IDLE_SECS=0`, behavior matches current code.
+- With a positive timeout on CUDA or Vulkan, idle transformer and vocoder weight
+  buffers are copied to RAM and GPU buffers are freed after the timeout.
+- The next request reloads from RAM, not from GGUF disk reads, and completes
+  synthesis.
+- Public non-synthesis tensor accessors also reload from RAM before reading
+  offloaded tensors.
+- No offload occurs during active synthesis or another guarded public operation.
+- Engine teardown and model reload stop the idle worker before freeing component
+  GGML resources.
+- Unsupported backends remain functional and do not attempt offload.
+- Errors during offload or reload are explicit and do not silently switch to a
+  different loading strategy.

--- a/src/common/gpu_offload_policy.cpp
+++ b/src/common/gpu_offload_policy.cpp
@@ -1,0 +1,38 @@
+#include "common/gpu_offload_policy.h"
+
+#include <cerrno>
+#include <climits>
+#include <cstdlib>
+
+namespace qwen3_tts {
+
+gpu_offload_policy parse_gpu_offload_policy(const char * idle_env, bool low_mem_enabled) {
+    gpu_offload_policy out;
+    if (low_mem_enabled) {
+        out.reason = "disabled because QWEN3_TTS_LOW_MEM is enabled";
+        return out;
+    }
+    if (!idle_env || idle_env[0] == '\0') {
+        out.reason = "unset";
+        return out;
+    }
+
+    errno = 0;
+    char * end = nullptr;
+    long parsed = std::strtol(idle_env, &end, 10);
+    if (errno != 0 || end == idle_env || *end != '\0' || parsed < 0 || parsed > INT_MAX) {
+        out.reason = "invalid value, disabled";
+        return out;
+    }
+    if (parsed == 0) {
+        out.reason = "disabled";
+        return out;
+    }
+
+    out.enabled = true;
+    out.idle_secs = (int) parsed;
+    out.reason = "enabled";
+    return out;
+}
+
+} // namespace qwen3_tts

--- a/src/common/gpu_offload_policy.cpp
+++ b/src/common/gpu_offload_policy.cpp
@@ -1,8 +1,6 @@
 #include "common/gpu_offload_policy.h"
 
-#include <cerrno>
 #include <climits>
-#include <cstdlib>
 
 namespace qwen3_tts {
 
@@ -17,20 +15,28 @@ gpu_offload_policy parse_gpu_offload_policy(const char * idle_env, bool low_mem_
         return out;
     }
 
-    errno = 0;
-    char * end = nullptr;
-    long parsed = std::strtol(idle_env, &end, 10);
-    if (errno != 0 || end == idle_env || *end != '\0' || parsed < 0 || parsed > INT_MAX) {
-        out.reason = "invalid value, disabled";
-        return out;
+    int parsed = 0;
+    for (const char * p = idle_env; *p != '\0'; ++p) {
+        if (*p < '0' || *p > '9') {
+            out.reason = "invalid value, disabled";
+            return out;
+        }
+
+        const int digit = *p - '0';
+        if (parsed > (INT_MAX - digit) / 10) {
+            out.reason = "invalid value, disabled";
+            return out;
+        }
+        parsed = parsed * 10 + digit;
     }
+
     if (parsed == 0) {
         out.reason = "disabled";
         return out;
     }
 
     out.enabled = true;
-    out.idle_secs = (int) parsed;
+    out.idle_secs = parsed;
     out.reason = "enabled";
     return out;
 }

--- a/src/common/gpu_offload_policy.h
+++ b/src/common/gpu_offload_policy.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+
+namespace qwen3_tts {
+
+struct gpu_offload_policy {
+    bool enabled = false;
+    int idle_secs = 0;
+    std::string reason;
+};
+
+gpu_offload_policy parse_gpu_offload_policy(const char * idle_env, bool low_mem_enabled);
+
+} // namespace qwen3_tts

--- a/src/common/weight_residency.cpp
+++ b/src/common/weight_residency.cpp
@@ -1,6 +1,7 @@
 #include "common/weight_residency.h"
 
 #include <cctype>
+#include <limits>
 #include <utility>
 #include <vector>
 
@@ -94,6 +95,11 @@ bool download_tensors_to_host(const std::map<std::string, ggml_tensor *> & tenso
             ggml_backend_tensor_get(tensor, copy.bytes.data(), 0, nbytes);
         }
 
+        if (nbytes > std::numeric_limits<size_t>::max() - out.total_bytes) {
+            error = "Host tensor store byte count overflow";
+            out.clear();
+            return false;
+        }
         out.total_bytes += nbytes;
         out.tensors.push_back(std::move(copy));
     }
@@ -109,6 +115,10 @@ bool upload_tensors_from_host(ggml_context * ctx,
                               std::string & error) {
     error.clear();
 
+    if (buffer) {
+        error = "Cannot upload tensors: destination buffer must be null";
+        return false;
+    }
     if (!ctx) {
         error = "Cannot upload tensors: ggml context is null";
         return false;

--- a/src/common/weight_residency.cpp
+++ b/src/common/weight_residency.cpp
@@ -163,6 +163,23 @@ bool upload_tensors_from_host(ggml_context * ctx,
         return false;
     }
 
+    for (ggml_tensor * tensor = ggml_get_first_tensor(ctx);
+         tensor;
+         tensor = ggml_get_next_tensor(ctx, tensor)) {
+        bool found = false;
+        for (const auto & entry : tensors) {
+            if (entry.second == tensor) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            error = "Destination tensor map does not cover context tensor: "
+                + std::string(tensor->name);
+            return false;
+        }
+    }
+
     for (const auto & entry : tensors) {
         auto copy_it = store_by_name.find(entry.first);
         if (copy_it == store_by_name.end()) {

--- a/src/common/weight_residency.cpp
+++ b/src/common/weight_residency.cpp
@@ -145,24 +145,42 @@ bool upload_tensors_from_host(ggml_context * ctx,
         return false;
     }
 
+    std::map<std::string, const host_tensor_copy *> store_by_name;
     for (const host_tensor_copy & copy : store.tensors) {
-        auto it = tensors.find(copy.name);
-        if (it == tensors.end()) {
+        if (store_by_name.find(copy.name) != store_by_name.end()) {
+            error = "Cannot upload duplicate tensor copy: " + copy.name;
+            return false;
+        }
+        if (tensors.find(copy.name) == tensors.end()) {
             error = "Cannot upload tensor not present in destination map: " + copy.name;
             return false;
         }
-        if (!it->second) {
-            error = "Cannot upload to null tensor: " + copy.name;
+        store_by_name[copy.name] = &copy;
+    }
+
+    if (store.tensors.size() != tensors.size()) {
+        error = "incomplete host tensor store for destination tensor map";
+        return false;
+    }
+
+    for (const auto & entry : tensors) {
+        auto copy_it = store_by_name.find(entry.first);
+        if (copy_it == store_by_name.end()) {
+            error = "Cannot upload missing tensor copy: " + entry.first;
             return false;
         }
-        if (!tensor_belongs_to_context(ctx, it->second)) {
-            error = "Cannot upload tensor from a different context: " + copy.name;
+        if (!entry.second) {
+            error = "Cannot upload to null tensor: " + entry.first;
+            return false;
+        }
+        if (!tensor_belongs_to_context(ctx, entry.second)) {
+            error = "Cannot upload tensor from a different context: " + entry.first;
             return false;
         }
 
-        const size_t expected = ggml_nbytes(it->second);
-        if (copy.bytes.size() != expected) {
-            error = "Cannot upload tensor with mismatched byte size: " + copy.name;
+        const size_t expected = ggml_nbytes(entry.second);
+        if (copy_it->second->bytes.size() != expected) {
+            error = "Cannot upload tensor with mismatched byte size: " + entry.first;
             return false;
         }
     }

--- a/src/common/weight_residency.cpp
+++ b/src/common/weight_residency.cpp
@@ -156,7 +156,14 @@ bool upload_tensors_from_host(ggml_context * ctx,
     }
 
     std::map<std::string, const host_tensor_copy *> store_by_name;
+    size_t store_total_bytes = 0;
     for (const host_tensor_copy & copy : store.tensors) {
+        if (copy.bytes.size() > std::numeric_limits<size_t>::max() - store_total_bytes) {
+            error = "Host tensor store total byte count overflow";
+            return false;
+        }
+        store_total_bytes += copy.bytes.size();
+
         if (store_by_name.find(copy.name) != store_by_name.end()) {
             error = "Cannot upload duplicate tensor copy: " + copy.name;
             return false;
@@ -166,6 +173,11 @@ bool upload_tensors_from_host(ggml_context * ctx,
             return false;
         }
         store_by_name[copy.name] = &copy;
+    }
+
+    if (store_total_bytes != store.total_bytes) {
+        error = "Host tensor store total bytes mismatch";
+        return false;
     }
 
     if (store.tensors.size() != tensors.size()) {

--- a/src/common/weight_residency.cpp
+++ b/src/common/weight_residency.cpp
@@ -180,6 +180,7 @@ bool upload_tensors_from_host(ggml_context * ctx,
         }
     }
 
+    std::map<ggml_tensor *, std::string> tensor_names_by_ptr;
     for (const auto & entry : tensors) {
         auto copy_it = store_by_name.find(entry.first);
         if (copy_it == store_by_name.end()) {
@@ -190,6 +191,14 @@ bool upload_tensors_from_host(ggml_context * ctx,
             error = "Cannot upload to null tensor: " + entry.first;
             return false;
         }
+        auto ptr_it = tensor_names_by_ptr.find(entry.second);
+        if (ptr_it != tensor_names_by_ptr.end()) {
+            error = "Cannot upload duplicate destination tensor alias: "
+                + ptr_it->second + " and " + entry.first;
+            return false;
+        }
+        tensor_names_by_ptr[entry.second] = entry.first;
+
         if (!tensor_belongs_to_context(ctx, entry.second)) {
             error = "Cannot upload tensor from a different context: " + entry.first;
             return false;

--- a/src/common/weight_residency.cpp
+++ b/src/common/weight_residency.cpp
@@ -87,6 +87,12 @@ bool download_tensors_to_host(const std::map<std::string, ggml_tensor *> & tenso
     for (const auto & entry : tensors) {
         ggml_tensor * tensor = entry.second;
         const size_t nbytes = ggml_nbytes(tensor);
+        ggml_backend_buffer_t buf = tensor->view_src ? tensor->view_src->buffer : tensor->buffer;
+        if (nbytes > 0 && (!buf || !tensor->data)) {
+            error = "Cannot download unallocated tensor: " + entry.first;
+            out.clear();
+            return false;
+        }
 
         host_tensor_copy copy;
         copy.name = entry.first;

--- a/src/common/weight_residency.cpp
+++ b/src/common/weight_residency.cpp
@@ -154,6 +154,10 @@ bool upload_tensors_from_host(ggml_context * ctx,
         error = "Cannot upload tensors: backend is null";
         return false;
     }
+    if (!ggml_get_no_alloc(ctx)) {
+        error = "Cannot upload tensors: ggml context must be no_alloc";
+        return false;
+    }
 
     std::map<std::string, const host_tensor_copy *> store_by_name;
     size_t store_total_bytes = 0;

--- a/src/common/weight_residency.cpp
+++ b/src/common/weight_residency.cpp
@@ -51,6 +51,17 @@ void restore_context_tensors(const std::vector<tensor_allocation_state> & states
     }
 }
 
+bool tensor_belongs_to_context(ggml_context * ctx, const ggml_tensor * target) {
+    for (ggml_tensor * tensor = ggml_get_first_tensor(ctx);
+         tensor;
+         tensor = ggml_get_next_tensor(ctx, tensor)) {
+        if (tensor == target) {
+            return true;
+        }
+    }
+    return false;
+}
+
 } // namespace
 
 void host_tensor_store::clear() {
@@ -142,6 +153,10 @@ bool upload_tensors_from_host(ggml_context * ctx,
         }
         if (!it->second) {
             error = "Cannot upload to null tensor: " + copy.name;
+            return false;
+        }
+        if (!tensor_belongs_to_context(ctx, it->second)) {
+            error = "Cannot upload tensor from a different context: " + copy.name;
             return false;
         }
 

--- a/src/common/weight_residency.cpp
+++ b/src/common/weight_residency.cpp
@@ -1,0 +1,158 @@
+#include "common/weight_residency.h"
+
+#include <cctype>
+#include <utility>
+#include <vector>
+
+namespace qwen3_tts {
+
+namespace {
+
+struct tensor_allocation_state {
+    ggml_tensor * tensor = nullptr;
+    ggml_backend_buffer_t buffer = nullptr;
+    void * data = nullptr;
+    void * extra = nullptr;
+};
+
+bool iequals(const char * a, const char * b) {
+    if (!a || !b) {
+        return false;
+    }
+    while (*a && *b) {
+        if (std::tolower((unsigned char) *a) != std::tolower((unsigned char) *b)) {
+            return false;
+        }
+        ++a;
+        ++b;
+    }
+    return *a == '\0' && *b == '\0';
+}
+
+std::vector<tensor_allocation_state> detach_context_tensors(ggml_context * ctx) {
+    std::vector<tensor_allocation_state> states;
+    for (ggml_tensor * tensor = ggml_get_first_tensor(ctx);
+         tensor;
+         tensor = ggml_get_next_tensor(ctx, tensor)) {
+        states.push_back({tensor, tensor->buffer, tensor->data, tensor->extra});
+        tensor->buffer = nullptr;
+        tensor->data = nullptr;
+        tensor->extra = nullptr;
+    }
+    return states;
+}
+
+void restore_context_tensors(const std::vector<tensor_allocation_state> & states) {
+    for (const tensor_allocation_state & state : states) {
+        state.tensor->buffer = state.buffer;
+        state.tensor->data = state.data;
+        state.tensor->extra = state.extra;
+    }
+}
+
+} // namespace
+
+void host_tensor_store::clear() {
+    tensors.clear();
+    total_bytes = 0;
+}
+
+bool backend_is_cuda_or_vulkan(ggml_backend_t backend) {
+    if (!backend) {
+        return false;
+    }
+
+    ggml_backend_dev_t dev = ggml_backend_get_device(backend);
+    ggml_backend_reg_t reg = dev ? ggml_backend_dev_backend_reg(dev) : nullptr;
+    const char * reg_name = reg ? ggml_backend_reg_name(reg) : nullptr;
+    return iequals(reg_name, "CUDA") || iequals(reg_name, "Vulkan");
+}
+
+bool download_tensors_to_host(const std::map<std::string, ggml_tensor *> & tensors,
+                              host_tensor_store & out,
+                              std::string & error) {
+    error.clear();
+    out.clear();
+
+    for (const auto & entry : tensors) {
+        if (!entry.second) {
+            error = "Cannot download null tensor: " + entry.first;
+            out.clear();
+            return false;
+        }
+    }
+
+    out.tensors.reserve(tensors.size());
+    for (const auto & entry : tensors) {
+        ggml_tensor * tensor = entry.second;
+        const size_t nbytes = ggml_nbytes(tensor);
+
+        host_tensor_copy copy;
+        copy.name = entry.first;
+        copy.bytes.resize(nbytes);
+        if (nbytes > 0) {
+            ggml_backend_tensor_get(tensor, copy.bytes.data(), 0, nbytes);
+        }
+
+        out.total_bytes += nbytes;
+        out.tensors.push_back(std::move(copy));
+    }
+
+    return true;
+}
+
+bool upload_tensors_from_host(ggml_context * ctx,
+                              const std::map<std::string, ggml_tensor *> & tensors,
+                              ggml_backend_t backend,
+                              const host_tensor_store & store,
+                              ggml_backend_buffer_t & buffer,
+                              std::string & error) {
+    error.clear();
+
+    if (!ctx) {
+        error = "Cannot upload tensors: ggml context is null";
+        return false;
+    }
+    if (!backend) {
+        error = "Cannot upload tensors: backend is null";
+        return false;
+    }
+
+    for (const host_tensor_copy & copy : store.tensors) {
+        auto it = tensors.find(copy.name);
+        if (it == tensors.end()) {
+            error = "Cannot upload tensor not present in destination map: " + copy.name;
+            return false;
+        }
+        if (!it->second) {
+            error = "Cannot upload to null tensor: " + copy.name;
+            return false;
+        }
+
+        const size_t expected = ggml_nbytes(it->second);
+        if (copy.bytes.size() != expected) {
+            error = "Cannot upload tensor with mismatched byte size: " + copy.name;
+            return false;
+        }
+    }
+
+    std::vector<tensor_allocation_state> old_states = detach_context_tensors(ctx);
+    ggml_backend_buffer_t new_buffer = ggml_backend_alloc_ctx_tensors(ctx, backend);
+    if (!new_buffer) {
+        restore_context_tensors(old_states);
+        error = "Failed to allocate backend tensor buffer";
+        return false;
+    }
+
+    for (const host_tensor_copy & copy : store.tensors) {
+        ggml_tensor * tensor = tensors.find(copy.name)->second;
+        if (!copy.bytes.empty()) {
+            ggml_backend_tensor_set(tensor, copy.bytes.data(), 0, copy.bytes.size());
+        }
+    }
+
+    buffer = new_buffer;
+    return true;
+}
+
+} // namespace qwen3_tts

--- a/src/common/weight_residency.cpp
+++ b/src/common/weight_residency.cpp
@@ -62,6 +62,11 @@ bool tensor_belongs_to_context(ggml_context * ctx, const ggml_tensor * target) {
     return false;
 }
 
+bool tensor_name_matches_key(const std::string & key, const ggml_tensor * tensor) {
+    const char * name = ggml_get_name(tensor);
+    return name && name[0] != '\0' && key == name;
+}
+
 } // namespace
 
 void host_tensor_store::clear() {
@@ -89,6 +94,11 @@ bool download_tensors_to_host(const std::map<std::string, ggml_tensor *> & tenso
     for (const auto & entry : tensors) {
         if (!entry.second) {
             error = "Cannot download null tensor: " + entry.first;
+            out.clear();
+            return false;
+        }
+        if (!tensor_name_matches_key(entry.first, entry.second)) {
+            error = "Cannot download tensor with mismatched name: " + entry.first;
             out.clear();
             return false;
         }
@@ -189,6 +199,10 @@ bool upload_tensors_from_host(ggml_context * ctx,
         }
         if (!entry.second) {
             error = "Cannot upload to null tensor: " + entry.first;
+            return false;
+        }
+        if (!tensor_name_matches_key(entry.first, entry.second)) {
+            error = "Cannot upload tensor with mismatched name: " + entry.first;
             return false;
         }
         auto ptr_it = tensor_names_by_ptr.find(entry.second);

--- a/src/common/weight_residency.h
+++ b/src/common/weight_residency.h
@@ -37,10 +37,11 @@ bool download_tensors_to_host(const std::map<std::string, ggml_tensor *> & tenso
 // tensor bytes into it. Tensor maps must be keyed by each tensor's GGML
 // metadata name.
 // Precondition: buffer must be nullptr on entry; callers own and must free any
-// previous backend buffer before reloading weights. Destination tensors must
-// belong to ctx. Destination names must map one-to-one to distinct tensor
-// pointers. The host store must contain exactly one copy for every destination
-// tensor in tensors, and tensors must cover every tensor in ctx.
+// previous backend buffer before reloading weights. ctx must be a no_alloc
+// GGML context. Destination tensors must belong to ctx. Destination names must
+// map one-to-one to distinct tensor pointers. The host store must contain
+// exactly one copy for every destination tensor in tensors, and tensors must
+// cover every tensor in ctx.
 bool upload_tensors_from_host(ggml_context * ctx,
                               const std::map<std::string, ggml_tensor *> & tensors,
                               ggml_backend_t backend,

--- a/src/common/weight_residency.h
+++ b/src/common/weight_residency.h
@@ -33,11 +33,12 @@ bool download_tensors_to_host(const std::map<std::string, ggml_tensor *> & tenso
                               host_tensor_store & out,
                               std::string & error);
 
-// Allocates a new backend buffer and uploads stored tensor bytes into it.
+// Allocates a new backend buffer for all tensors in ctx and uploads stored
+// tensor bytes into it.
 // Precondition: buffer must be nullptr on entry; callers own and must free any
 // previous backend buffer before reloading weights. Destination tensors must
 // belong to ctx. The host store must contain exactly one copy for every
-// destination tensor in tensors.
+// destination tensor in tensors, and tensors must cover every tensor in ctx.
 bool upload_tensors_from_host(ggml_context * ctx,
                               const std::map<std::string, ggml_tensor *> & tensors,
                               ggml_backend_t backend,

--- a/src/common/weight_residency.h
+++ b/src/common/weight_residency.h
@@ -37,8 +37,9 @@ bool download_tensors_to_host(const std::map<std::string, ggml_tensor *> & tenso
 // tensor bytes into it.
 // Precondition: buffer must be nullptr on entry; callers own and must free any
 // previous backend buffer before reloading weights. Destination tensors must
-// belong to ctx. The host store must contain exactly one copy for every
-// destination tensor in tensors, and tensors must cover every tensor in ctx.
+// belong to ctx. Destination names must map one-to-one to distinct tensor
+// pointers. The host store must contain exactly one copy for every destination
+// tensor in tensors, and tensors must cover every tensor in ctx.
 bool upload_tensors_from_host(ggml_context * ctx,
                               const std::map<std::string, ggml_tensor *> & tensors,
                               ggml_backend_t backend,

--- a/src/common/weight_residency.h
+++ b/src/common/weight_residency.h
@@ -36,7 +36,8 @@ bool download_tensors_to_host(const std::map<std::string, ggml_tensor *> & tenso
 // Allocates a new backend buffer and uploads stored tensor bytes into it.
 // Precondition: buffer must be nullptr on entry; callers own and must free any
 // previous backend buffer before reloading weights. Destination tensors must
-// belong to ctx.
+// belong to ctx. The host store must contain exactly one copy for every
+// destination tensor in tensors.
 bool upload_tensors_from_host(ggml_context * ctx,
                               const std::map<std::string, ggml_tensor *> & tensors,
                               ggml_backend_t backend,

--- a/src/common/weight_residency.h
+++ b/src/common/weight_residency.h
@@ -32,6 +32,10 @@ bool backend_is_cuda_or_vulkan(ggml_backend_t backend);
 bool download_tensors_to_host(const std::map<std::string, ggml_tensor *> & tensors,
                               host_tensor_store & out,
                               std::string & error);
+
+// Allocates a new backend buffer and uploads stored tensor bytes into it.
+// Precondition: buffer must be nullptr on entry; callers own and must free any
+// previous backend buffer before reloading weights.
 bool upload_tensors_from_host(ggml_context * ctx,
                               const std::map<std::string, ggml_tensor *> & tensors,
                               ggml_backend_t backend,

--- a/src/common/weight_residency.h
+++ b/src/common/weight_residency.h
@@ -35,7 +35,8 @@ bool download_tensors_to_host(const std::map<std::string, ggml_tensor *> & tenso
 
 // Allocates a new backend buffer and uploads stored tensor bytes into it.
 // Precondition: buffer must be nullptr on entry; callers own and must free any
-// previous backend buffer before reloading weights.
+// previous backend buffer before reloading weights. Destination tensors must
+// belong to ctx.
 bool upload_tensors_from_host(ggml_context * ctx,
                               const std::map<std::string, ggml_tensor *> & tensors,
                               ggml_backend_t backend,

--- a/src/common/weight_residency.h
+++ b/src/common/weight_residency.h
@@ -34,7 +34,8 @@ bool download_tensors_to_host(const std::map<std::string, ggml_tensor *> & tenso
                               std::string & error);
 
 // Allocates a new backend buffer for all tensors in ctx and uploads stored
-// tensor bytes into it.
+// tensor bytes into it. Tensor maps must be keyed by each tensor's GGML
+// metadata name.
 // Precondition: buffer must be nullptr on entry; callers own and must free any
 // previous backend buffer before reloading weights. Destination tensors must
 // belong to ctx. Destination names must map one-to-one to distinct tensor

--- a/src/common/weight_residency.h
+++ b/src/common/weight_residency.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "ggml.h"
+#include "ggml-backend.h"
+
+#include <cstdint>
+#include <cstddef>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace qwen3_tts {
+
+enum class weight_residency {
+    Unloaded,
+    GpuResident,
+    RamResident,
+};
+
+struct host_tensor_copy {
+    std::string name;
+    std::vector<uint8_t> bytes;
+};
+
+struct host_tensor_store {
+    std::vector<host_tensor_copy> tensors;
+    size_t total_bytes = 0;
+    void clear();
+};
+
+bool backend_is_cuda_or_vulkan(ggml_backend_t backend);
+bool download_tensors_to_host(const std::map<std::string, ggml_tensor *> & tensors,
+                              host_tensor_store & out,
+                              std::string & error);
+bool upload_tensors_from_host(ggml_context * ctx,
+                              const std::map<std::string, ggml_tensor *> & tensors,
+                              ggml_backend_t backend,
+                              const host_tensor_store & store,
+                              ggml_backend_buffer_t & buffer,
+                              std::string & error);
+
+} // namespace qwen3_tts

--- a/src/decoder/audio_tokenizer_decoder.cpp
+++ b/src/decoder/audio_tokenizer_decoder.cpp
@@ -35,6 +35,40 @@ static int32_t get_env_i32(const char * key, int32_t default_value) {
     return (int32_t) parsed;
 }
 
+namespace {
+
+bool create_decoder_scheduler(audio_decoder_state & state, std::string & error) {
+    std::vector<ggml_backend_t> backends;
+    backends.push_back(state.backend);
+    if (state.backend_cpu) {
+        backends.push_back(state.backend_cpu);
+    }
+
+    state.sched = ggml_backend_sched_new(backends.data(), nullptr, (int) backends.size(),
+                                         QWEN3_TTS_DEC_MAX_NODES, false, true);
+    if (!state.sched) {
+        error = "Failed to create backend scheduler";
+        return false;
+    }
+    return true;
+}
+
+void clear_context_tensor_allocations(ggml_context * ctx) {
+    if (!ctx) {
+        return;
+    }
+
+    for (ggml_tensor * tensor = ggml_get_first_tensor(ctx);
+         tensor;
+         tensor = ggml_get_next_tensor(ctx, tensor)) {
+        tensor->buffer = nullptr;
+        tensor->data = nullptr;
+        tensor->extra = nullptr;
+    }
+}
+
+} // namespace
+
 AudioTokenizerDecoder::AudioTokenizerDecoder() = default;
 
 AudioTokenizerDecoder::~AudioTokenizerDecoder() {
@@ -381,19 +415,128 @@ bool AudioTokenizerDecoder::load_model(const std::string & model_path) {
         }
     }
 
-    std::vector<ggml_backend_t> backends;
-    backends.push_back(state_.backend);
-    if (state_.backend_cpu) {
-        backends.push_back(state_.backend_cpu);
-    }
-    state_.sched = ggml_backend_sched_new(backends.data(), nullptr, (int)backends.size(), QWEN3_TTS_DEC_MAX_NODES, false, true);
-    if (!state_.sched) {
-        error_msg_ = "Failed to create backend scheduler";
+    if (!create_decoder_scheduler(state_, error_msg_)) {
         return false;
     }
 
     state_.compute_meta.resize(ggml_tensor_overhead() * QWEN3_TTS_DEC_MAX_NODES + ggml_graph_overhead());
+
+    model_.host_weights.clear();
+    model_.residency = weight_residency::GpuResident;
     
+    return true;
+}
+
+bool AudioTokenizerDecoder::can_offload_to_ram() const {
+    return model_.residency == weight_residency::GpuResident &&
+           model_.buffer != nullptr &&
+           backend_is_cuda_or_vulkan(state_.backend);
+}
+
+bool AudioTokenizerDecoder::offload_weights_to_ram(std::string & error) {
+    error.clear();
+
+    if (model_.residency == weight_residency::RamResident) {
+        return true;
+    }
+    if (model_.residency != weight_residency::GpuResident) {
+        error = "Cannot offload decoder weights: model weights are not GPU-resident";
+        return false;
+    }
+    if (!model_.buffer) {
+        error = "Cannot offload decoder weights: model buffer is null";
+        return false;
+    }
+    if (!can_offload_to_ram()) {
+        error = "Cannot offload decoder weights: backend does not support RAM offload";
+        return false;
+    }
+
+    if (state_.sched) {
+        ggml_backend_sched_reset(state_.sched);
+    }
+
+    if (!download_tensors_to_host(model_.tensors, model_.host_weights, error)) {
+        model_.host_weights.clear();
+        model_.residency = weight_residency::GpuResident;
+        return false;
+    }
+
+    if (state_.sched) {
+        ggml_backend_sched_free(state_.sched);
+        state_.sched = nullptr;
+    }
+    ggml_backend_buffer_free(model_.buffer);
+    model_.buffer = nullptr;
+    clear_context_tensor_allocations(model_.ctx);
+    model_.residency = weight_residency::RamResident;
+    codes_buf_.clear();
+    return true;
+}
+
+bool AudioTokenizerDecoder::reload_weights_from_ram(std::string & error) {
+    error.clear();
+
+    if (model_.residency == weight_residency::GpuResident) {
+        return true;
+    }
+    if (model_.residency != weight_residency::RamResident) {
+        error = "Cannot reload decoder weights: model weights are not RAM-resident";
+        return false;
+    }
+    if (!model_.ctx) {
+        error = "Cannot reload decoder weights: ggml context is null";
+        return false;
+    }
+    if (!state_.backend) {
+        error = "Cannot reload decoder weights: backend is null";
+        return false;
+    }
+    if (model_.host_weights.tensors.empty() || model_.host_weights.total_bytes == 0) {
+        error = "Cannot reload decoder weights: host tensor store is empty";
+        return false;
+    }
+    if (model_.buffer) {
+        error = "Cannot reload decoder weights: model buffer must be null";
+        return false;
+    }
+
+    if (!upload_tensors_from_host(model_.ctx, model_.tensors, state_.backend,
+                                  model_.host_weights, model_.buffer, error)) {
+        model_.buffer = nullptr;
+        model_.residency = weight_residency::RamResident;
+        return false;
+    }
+
+    if (!state_.sched && !create_decoder_scheduler(state_, error)) {
+        ggml_backend_buffer_free(model_.buffer);
+        model_.buffer = nullptr;
+        clear_context_tensor_allocations(model_.ctx);
+        model_.residency = weight_residency::RamResident;
+        if (error.empty()) {
+            error = "Failed to recreate decoder scheduler after weight reload";
+        }
+        return false;
+    }
+
+    model_.host_weights.clear();
+    model_.residency = weight_residency::GpuResident;
+    return true;
+}
+
+bool AudioTokenizerDecoder::is_ram_offloaded() const {
+    return model_.residency == weight_residency::RamResident;
+}
+
+size_t AudioTokenizerDecoder::ram_offloaded_bytes() const {
+    return model_.host_weights.total_bytes;
+}
+
+bool AudioTokenizerDecoder::require_weights_gpu_resident() {
+    if (model_.residency == weight_residency::RamResident) {
+        error_msg_ = "Audio decoder weights are RAM-offloaded; reload_weights_from_ram() first";
+        return false;
+    }
     return true;
 }
 
@@ -987,6 +1130,10 @@ bool AudioTokenizerDecoder::decode_chunked_cuda(const int32_t * codes, int32_t n
 
 bool AudioTokenizerDecoder::decode(const int32_t * codes, int32_t n_frames,
                                     std::vector<float> & samples) {
+    if (!require_weights_gpu_resident()) {
+        return false;
+    }
+
     if (!model_.ctx) {
         error_msg_ = "Model not loaded";
         return false;
@@ -1017,6 +1164,8 @@ void free_audio_decoder_model(audio_decoder_model & model) {
         ggml_free(model.ctx);
         model.ctx = nullptr;
     }
+    model.host_weights.clear();
+    model.residency = weight_residency::Unloaded;
     model.tensors.clear();
 }
 

--- a/src/decoder/audio_tokenizer_decoder.cpp
+++ b/src/decoder/audio_tokenizer_decoder.cpp
@@ -180,6 +180,13 @@ bool AudioTokenizerDecoder::load_model(const std::string & model_path) {
         error_msg_ = "Failed to initialize GGML context";
         return false;
     }
+
+    auto fail_after_context_created = [this]() {
+        const std::string failure = error_msg_;
+        unload_model();
+        error_msg_ = failure;
+        return false;
+    };
     
     struct gguf_context * gguf_ctx = loader.get_ctx();
     struct ggml_context * meta_ctx = loader.get_meta_ctx();
@@ -387,7 +394,7 @@ bool AudioTokenizerDecoder::load_model(const std::string & model_path) {
     if (!load_tensor_data_from_file(model_path, gguf_ctx, model_.ctx,
                                      model_.tensors, model_.buffer, error_msg_,
                                      GGML_BACKEND_DEVICE_TYPE_IGPU)) {
-        return false;
+        return fail_after_context_created();
     }
     
     for (int i = 0; i < 4; ++i) {
@@ -400,7 +407,7 @@ bool AudioTokenizerDecoder::load_model(const std::string & model_path) {
 
     state_.backend = init_preferred_backend("AudioTokenizerDecoder", &error_msg_);
     if (!state_.backend) {
-        return false;
+        return fail_after_context_created();
     }
 
     ggml_backend_dev_t device = ggml_backend_get_device(state_.backend);
@@ -411,12 +418,12 @@ bool AudioTokenizerDecoder::load_model(const std::string & model_path) {
         state_.backend_cpu = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, nullptr);
         if (!state_.backend_cpu) {
             error_msg_ = "Failed to initialize CPU fallback backend for AudioTokenizerDecoder";
-            return false;
+            return fail_after_context_created();
         }
     }
 
     if (!create_decoder_scheduler(state_, error_msg_)) {
-        return false;
+        return fail_after_context_created();
     }
 
     state_.compute_meta.resize(ggml_tensor_overhead() * QWEN3_TTS_DEC_MAX_NODES + ggml_graph_overhead());
@@ -535,6 +542,14 @@ size_t AudioTokenizerDecoder::ram_offloaded_bytes() const {
 bool AudioTokenizerDecoder::require_weights_gpu_resident() {
     if (model_.residency == weight_residency::RamResident) {
         error_msg_ = "Audio decoder weights are RAM-offloaded; reload_weights_from_ram() first";
+        return false;
+    }
+    if (model_.residency == weight_residency::Unloaded) {
+        error_msg_ = "Audio decoder model is not loaded";
+        return false;
+    }
+    if (model_.residency != weight_residency::GpuResident) {
+        error_msg_ = "Audio decoder weights are not GPU-resident";
         return false;
     }
     return true;
@@ -1164,9 +1179,7 @@ void free_audio_decoder_model(audio_decoder_model & model) {
         ggml_free(model.ctx);
         model.ctx = nullptr;
     }
-    model.host_weights.clear();
-    model.residency = weight_residency::Unloaded;
-    model.tensors.clear();
+    model = audio_decoder_model();
 }
 
 } // namespace qwen3_tts

--- a/src/decoder/audio_tokenizer_decoder.cpp
+++ b/src/decoder/audio_tokenizer_decoder.cpp
@@ -441,6 +441,10 @@ bool AudioTokenizerDecoder::can_offload_to_ram() const {
 }
 
 bool AudioTokenizerDecoder::offload_weights_to_ram(std::string & error) {
+    return offload_weights_to_ram(error, true);
+}
+
+bool AudioTokenizerDecoder::offload_weights_to_ram(std::string & error, bool require_supported_backend) {
     error.clear();
 
     if (model_.residency == weight_residency::RamResident) {
@@ -454,7 +458,7 @@ bool AudioTokenizerDecoder::offload_weights_to_ram(std::string & error) {
         error = "Cannot offload decoder weights: model buffer is null";
         return false;
     }
-    if (!can_offload_to_ram()) {
+    if (require_supported_backend && !can_offload_to_ram()) {
         error = "Cannot offload decoder weights: backend does not support RAM offload";
         return false;
     }

--- a/src/decoder/audio_tokenizer_decoder.h
+++ b/src/decoder/audio_tokenizer_decoder.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "common/weight_residency.h"
 #include "ggml.h"
 #include "ggml-backend.h"
 #include "gguf.h"
@@ -144,6 +145,9 @@ struct audio_decoder_model {
     
     // Tensor name to tensor mapping
     std::map<std::string, struct ggml_tensor *> tensors;
+
+    weight_residency residency = weight_residency::Unloaded;
+    host_tensor_store host_weights;
 };
 
 // Compute state for decoder
@@ -173,6 +177,12 @@ public:
     // Returns: audio samples normalized to [-1, 1] at 24kHz
     bool decode(const int32_t * codes, int32_t n_frames,
                 std::vector<float> & samples);
+
+    bool can_offload_to_ram() const;
+    bool offload_weights_to_ram(std::string & error);
+    bool reload_weights_from_ram(std::string & error);
+    bool is_ram_offloaded() const;
+    size_t ram_offloaded_bytes() const;
     
     const audio_decoder_config & get_config() const { return model_.config; }
     
@@ -188,6 +198,7 @@ private:
                              std::vector<float> & samples,
                              int32_t max_gpu_frames, int32_t context_frames_cfg);
     int64_t output_samples_for_frames(int32_t n_frames) const;
+    bool require_weights_gpu_resident();
     
     // Apply Snake activation: x + (1/alpha) * sin^2(alpha * x)
     struct ggml_tensor * apply_snake(struct ggml_context * ctx,

--- a/src/decoder/audio_tokenizer_decoder.h
+++ b/src/decoder/audio_tokenizer_decoder.h
@@ -12,6 +12,8 @@
 
 namespace qwen3_tts {
 
+class Qwen3TTS;
+
 // Audio tokenizer decoder (vocoder) configuration
 struct audio_decoder_config {
     int32_t sample_rate = 24000;
@@ -189,6 +191,10 @@ public:
     const std::string & get_error() const { return error_msg_; }
     
 private:
+    friend class Qwen3TTS;
+
+    bool offload_weights_to_ram(std::string & error, bool require_supported_backend);
+
     // Build computation graph for decoding
     struct ggml_cgraph * build_graph(int32_t n_frames);
     bool decode_single(const int32_t * codes, int32_t n_frames, int32_t position_offset,

--- a/src/encoder/audio_tokenizer_encoder.cpp
+++ b/src/encoder/audio_tokenizer_encoder.cpp
@@ -6,6 +6,7 @@
 #include <cstring>
 #include <algorithm>
 #include <numeric>
+#include <utility>
 
 #define QWEN3_TTS_MAX_NODES 16384
 
@@ -127,6 +128,10 @@ static void compute_centered_window(float * window, int n_fft, int win_length) {
 AudioTokenizerEncoder::AudioTokenizerEncoder() = default;
 
 AudioTokenizerEncoder::~AudioTokenizerEncoder() {
+    unload_model();
+}
+
+void AudioTokenizerEncoder::unload_model() {
     free_speaker_encoder_model(model_);
     
     if (state_.sched) {
@@ -141,13 +146,22 @@ AudioTokenizerEncoder::~AudioTokenizerEncoder() {
         ggml_backend_free(state_.backend_cpu);
         state_.backend_cpu = nullptr;
     }
+    state_.compute_meta.clear();
+    state_ = speaker_encoder_state();
 }
 
 bool AudioTokenizerEncoder::load_model(const std::string & model_path) {
+    unload_model();
+
+    auto fail_load = [this](std::string error) {
+        unload_model();
+        error_msg_ = std::move(error);
+        return false;
+    };
+
     GGUFLoader loader;
     if (!loader.open(model_path)) {
-        error_msg_ = loader.get_error();
-        return false;
+        return fail_load(loader.get_error());
     }
     
     model_.config.sample_rate = loader.get_u32("qwen3-tts.speaker_encoder.sample_rate", 24000);
@@ -163,8 +177,7 @@ bool AudioTokenizerEncoder::load_model(const std::string & model_path) {
     }
     
     if (spk_tensor_count == 0) {
-        error_msg_ = "No speaker encoder tensors found in model";
-        return false;
+        return fail_load("No speaker encoder tensors found in model");
     }
     
     size_t ctx_size = ggml_tensor_overhead() * spk_tensor_count;
@@ -176,8 +189,7 @@ bool AudioTokenizerEncoder::load_model(const std::string & model_path) {
     
     model_.ctx = ggml_init(params);
     if (!model_.ctx) {
-        error_msg_ = "Failed to initialize GGML context";
-        return false;
+        return fail_load("Failed to initialize GGML context");
     }
     
     struct gguf_context * gguf_ctx = loader.get_ctx();
@@ -250,12 +262,12 @@ bool AudioTokenizerEncoder::load_model(const std::string & model_path) {
     
     if (!load_tensor_data_from_file(model_path, gguf_ctx, model_.ctx, 
                                      model_.tensors, model_.buffer, error_msg_)) {
-        return false;
+        return fail_load(error_msg_);
     }
     
     state_.backend = init_preferred_backend("AudioTokenizerEncoder", &error_msg_);
     if (!state_.backend) {
-        return false;
+        return fail_load(error_msg_);
     }
     ggml_backend_dev_t device = ggml_backend_get_device(state_.backend);
     const char * device_name = device ? ggml_backend_dev_name(device) : "Unknown";
@@ -264,8 +276,7 @@ bool AudioTokenizerEncoder::load_model(const std::string & model_path) {
     if (device && ggml_backend_dev_type(device) != GGML_BACKEND_DEVICE_TYPE_CPU) {
         state_.backend_cpu = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, nullptr);
         if (!state_.backend_cpu) {
-            error_msg_ = "Failed to initialize CPU fallback backend for AudioTokenizerEncoder";
-            return false;
+            return fail_load("Failed to initialize CPU fallback backend for AudioTokenizerEncoder");
         }
     }
 
@@ -276,8 +287,7 @@ bool AudioTokenizerEncoder::load_model(const std::string & model_path) {
     }
     state_.sched = ggml_backend_sched_new(backends.data(), nullptr, (int)backends.size(), QWEN3_TTS_MAX_NODES, false, true);
     if (!state_.sched) {
-        error_msg_ = "Failed to create backend scheduler";
-        return false;
+        return fail_load("Failed to create backend scheduler");
     }
     
     state_.compute_meta.resize(ggml_tensor_overhead() * QWEN3_TTS_MAX_NODES + ggml_graph_overhead());
@@ -702,7 +712,7 @@ struct ggml_cgraph * AudioTokenizerEncoder::build_graph(int32_t n_frames) {
 
 bool AudioTokenizerEncoder::encode(const float * samples, int32_t n_samples,
                                     std::vector<float> & embedding) {
-    if (!model_.ctx) {
+    if (!model_.ctx || !state_.backend || !state_.sched) {
         error_msg_ = "Model not loaded";
         return false;
     }
@@ -766,6 +776,7 @@ void free_speaker_encoder_model(speaker_encoder_model & model) {
         model.ctx = nullptr;
     }
     model.tensors.clear();
+    model = speaker_encoder_model();
 }
 
 } // namespace qwen3_tts

--- a/src/encoder/audio_tokenizer_encoder.h
+++ b/src/encoder/audio_tokenizer_encoder.h
@@ -100,6 +100,9 @@ public:
     
     // Load model from GGUF file (main TTS model, not tokenizer)
     bool load_model(const std::string & model_path);
+
+    // Release model/runtime resources
+    void unload_model();
     
     // Encode audio samples to speaker embedding
     // samples: audio samples normalized to [-1, 1], 24kHz

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,6 +39,7 @@ void print_usage(const char * program) {
     fprintf(stderr, "  QWEN3_TTS_DECODER_GPU_MAX_FRAMES     Max frames per CUDA vocoder chunk (default: 34)\n");
     fprintf(stderr, "  QWEN3_TTS_DECODER_GPU_CONTEXT_FRAMES Left context per CUDA vocoder chunk (default: 12)\n");
     fprintf(stderr, "  QWEN3_TTS_LOW_MEM      Enable low-memory mode (set to 1)\n");
+    fprintf(stderr, "  QWEN3_TTS_GPU_OFFLOAD_IDLE_SECS  CUDA/Vulkan idle RAM offload timeout (default: 0)\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "Example:\n");
     fprintf(stderr, "  %s -m ./models -t \"Hello, world!\" -o hello.wav\n", program);

--- a/src/pipeline/qwen3_tts.cpp
+++ b/src/pipeline/qwen3_tts.cpp
@@ -142,14 +142,16 @@ bool Qwen3TTS::ensure_runtime_resident_locked(uint32_t required, std::string & e
         }
     }
 
-    operation_active_ = true;
+    ++active_operations_;
     return true;
 }
 
 void Qwen3TTS::finish_guarded_operation_locked() {
-    operation_active_ = false;
+    if (active_operations_ > 0) {
+        --active_operations_;
+    }
     ++idle_generation_;
-    if (gpu_idle_offload_enabled_) {
+    if (gpu_idle_offload_enabled_ && active_operations_ == 0) {
         idle_cv_.notify_all();
     }
 }
@@ -185,7 +187,7 @@ void Qwen3TTS::stop_idle_worker() {
     {
         std::lock_guard<std::mutex> lock(lifecycle_mutex_);
         idle_worker_shutdown_ = false;
-        operation_active_ = false;
+        active_operations_ = 0;
         ++idle_generation_;
     }
 }
@@ -196,24 +198,32 @@ void Qwen3TTS::idle_worker_main() {
     for (;;) {
         idle_cv_.wait(lock, [this] {
             return idle_worker_shutdown_ ||
-                   (gpu_idle_offload_enabled_ && !operation_active_);
+                   (gpu_idle_offload_enabled_ && active_operations_ == 0);
         });
 
         if (idle_worker_shutdown_) {
             return;
         }
-        if (!gpu_idle_offload_enabled_ || operation_active_ || gpu_offload_idle_secs_ <= 0) {
+        if (!gpu_idle_offload_enabled_ || active_operations_ != 0 || gpu_offload_idle_secs_ <= 0) {
             continue;
         }
 
         const uint64_t generation = idle_generation_;
-        const auto idle_timeout = std::chrono::seconds(gpu_offload_idle_secs_);
-        idle_cv_.wait_for(lock, idle_timeout);
+        const auto deadline = std::chrono::steady_clock::now() +
+                              std::chrono::seconds(gpu_offload_idle_secs_);
+        const bool interrupted = idle_cv_.wait_until(lock, deadline, [this, generation] {
+            return idle_worker_shutdown_ ||
+                   !gpu_idle_offload_enabled_ ||
+                   active_operations_ != 0 ||
+                   idle_generation_ != generation ||
+                   gpu_offload_idle_secs_ <= 0;
+        });
 
         if (idle_worker_shutdown_) {
             return;
         }
-        if (!gpu_idle_offload_enabled_ || operation_active_ ||
+        if (interrupted ||
+            !gpu_idle_offload_enabled_ || active_operations_ != 0 ||
             idle_generation_ != generation || gpu_offload_idle_secs_ <= 0) {
             continue;
         }
@@ -316,7 +326,7 @@ bool Qwen3TTS::transformer_ram_offloaded_for_test() const {
 
 bool Qwen3TTS::force_idle_offload_once_for_test(std::string & error) {
     std::lock_guard<std::mutex> lock(lifecycle_mutex_);
-    if (operation_active_) {
+    if (active_operations_ != 0) {
         error = "Cannot force idle RAM offload while an operation is active";
         return false;
     }

--- a/src/pipeline/qwen3_tts.cpp
+++ b/src/pipeline/qwen3_tts.cpp
@@ -346,6 +346,11 @@ bool Qwen3TTS::transformer_ram_offloaded_for_test() const {
     return transformer_.is_ram_offloaded();
 }
 
+bool Qwen3TTS::decoder_ram_offloaded_for_test() const {
+    std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+    return audio_decoder_.is_ram_offloaded();
+}
+
 bool Qwen3TTS::force_idle_offload_once_for_test(std::string & error) {
     std::lock_guard<std::mutex> lock(lifecycle_mutex_);
     if (active_operations_ != 0) {

--- a/src/pipeline/qwen3_tts.cpp
+++ b/src/pipeline/qwen3_tts.cpp
@@ -93,6 +93,25 @@ static void log_memory_usage(const char * label) {
             format_bytes(mem.phys_footprint_bytes).c_str());
 }
 
+class guarded_operation {
+public:
+    guarded_operation(Qwen3TTS & tts, bool active)
+        : tts_(tts), active_(active) {}
+
+    ~guarded_operation() {
+        if (active_) {
+            tts_.finish_guarded_operation_locked();
+        }
+    }
+
+    guarded_operation(const guarded_operation &) = delete;
+    guarded_operation & operator=(const guarded_operation &) = delete;
+
+private:
+    Qwen3TTS & tts_;
+    bool active_;
+};
+
 static void resample_linear(const float * input, int input_len, int input_rate,
                             std::vector<float> & output, int output_rate) {
     double ratio = (double)input_rate / output_rate;
@@ -113,7 +132,9 @@ static void resample_linear(const float * input, int input_len, int input_rate,
     }
 }
 
-Qwen3TTS::Qwen3TTS() = default;
+Qwen3TTS::Qwen3TTS() {
+    publish_metadata_snapshot_locked(std::make_shared<model_metadata_snapshot>());
+}
 
 Qwen3TTS::~Qwen3TTS() {
     stop_idle_worker();
@@ -172,24 +193,25 @@ void Qwen3TTS::start_idle_worker_locked() {
     idle_worker_ = std::thread(&Qwen3TTS::idle_worker_main, this);
 }
 
-void Qwen3TTS::stop_idle_worker() {
-    {
-        std::lock_guard<std::mutex> lock(lifecycle_mutex_);
-        idle_worker_shutdown_ = true;
-        ++idle_generation_;
-        idle_cv_.notify_all();
-    }
+void Qwen3TTS::stop_idle_worker_locked(std::unique_lock<std::mutex> & lock) {
+    idle_worker_shutdown_ = true;
+    ++idle_generation_;
+    idle_cv_.notify_all();
 
+    lock.unlock();
     if (idle_worker_.joinable()) {
         idle_worker_.join();
     }
+    lock.lock();
 
-    {
-        std::lock_guard<std::mutex> lock(lifecycle_mutex_);
-        idle_worker_shutdown_ = false;
-        active_operations_ = 0;
-        ++idle_generation_;
-    }
+    idle_worker_shutdown_ = false;
+    active_operations_ = 0;
+    ++idle_generation_;
+}
+
+void Qwen3TTS::stop_idle_worker() {
+    std::unique_lock<std::mutex> lock(lifecycle_mutex_);
+    stop_idle_worker_locked(lock);
 }
 
 void Qwen3TTS::idle_worker_main() {
@@ -334,18 +356,51 @@ bool Qwen3TTS::force_idle_offload_once_for_test(std::string & error) {
     return offload_idle_components_locked(true, &error);
 }
 
+void Qwen3TTS::publish_metadata_snapshot_locked(
+        std::shared_ptr<const model_metadata_snapshot> snapshot) {
+    if (!snapshot) {
+        snapshot = std::make_shared<model_metadata_snapshot>();
+    }
+    metadata_snapshot_ = snapshot;
+    retained_metadata_snapshots_.push_back(std::move(snapshot));
+}
+
+const Qwen3TTS::model_metadata_snapshot & Qwen3TTS::metadata_snapshot_locked() const {
+    if (metadata_snapshot_) {
+        return *metadata_snapshot_;
+    }
+    static const model_metadata_snapshot empty;
+    return empty;
+}
+
 bool Qwen3TTS::load_models(const std::string & model_dir,
                            const std::string & tts_model,
                            const std::string & tokenizer_model) {
+    std::lock_guard<std::mutex> reload_lock(reload_mutex_);
+    std::unique_lock<std::mutex> lock(lifecycle_mutex_);
+
+    models_loaded_ = false;
+    publish_metadata_snapshot_locked(std::make_shared<model_metadata_snapshot>());
+    stop_idle_worker_locked(lock);
+
     int64_t t_start = get_time_ms();
     log_memory_usage("load/start");
 
-    stop_idle_worker();
-
     transformer_.unload_model();
     audio_decoder_.unload_model();
+    audio_encoder_.unload_model();
+    codec_encoder_.unload_model();
+    encoder_loaded_ = false;
+    codec_encoder_loaded_ = false;
     transformer_loaded_ = false;
     decoder_loaded_ = false;
+
+    auto fail_load = [this](const std::string & error) {
+        error_msg_ = error;
+        models_loaded_ = false;
+        ++idle_generation_;
+        return false;
+    };
 
     // Construct model paths — explicit paths override auto-detection
     if (!tts_model.empty()) {
@@ -368,6 +423,7 @@ bool Qwen3TTS::load_models(const std::string & model_dir,
         decoder_model_path_ = model_dir + "/qwen3-tts-tokenizer-f16.gguf";
     }
     encoder_loaded_ = false;
+    codec_encoder_loaded_ = false;
     transformer_loaded_ = false;
     decoder_loaded_ = false;
 
@@ -395,13 +451,11 @@ bool Qwen3TTS::load_models(const std::string & model_dir,
     {
         GGUFLoader loader;
         if (!loader.open(tts_model_path_)) {
-            error_msg_ = "Failed to open TTS model: " + loader.get_error();
-            return false;
+            return fail_load("Failed to open TTS model: " + loader.get_error());
         }
         
         if (!tokenizer_.load_from_gguf(loader.get_ctx())) {
-            error_msg_ = "Failed to load text tokenizer: " + tokenizer_.get_error();
-            return false;
+            return fail_load("Failed to load text tokenizer: " + tokenizer_.get_error());
         }
         fprintf(stderr, "  Text tokenizer loaded: vocab_size=%d (%lld ms)\n",
                 tokenizer_.get_config().vocab_size,
@@ -415,10 +469,17 @@ bool Qwen3TTS::load_models(const std::string & model_dir,
     // Load TTS transformer from TTS model
     int64_t t_transformer_start = get_time_ms();
     if (!transformer_.load_model(tts_model_path_)) {
-        error_msg_ = "Failed to load TTS transformer: " + transformer_.get_error();
-        return false;
+        return fail_load("Failed to load TTS transformer: " + transformer_.get_error());
     }
     transformer_loaded_ = true;
+    auto metadata = std::make_shared<model_metadata_snapshot>();
+    const auto & transformer_config = transformer_.get_config();
+    metadata->model_type = transformer_config.model_type;
+    metadata->model_size = transformer_config.model_size;
+    metadata->has_speaker_encoder = transformer_config.has_speaker_encoder;
+    metadata->speaker_names = transformer_config.speaker_names;
+    metadata->speaker_ids = transformer_config.speaker_ids;
+    metadata->speaker_dialects = transformer_config.speaker_dialects;
     fprintf(stderr, "  TTS transformer loaded: hidden_size=%d, n_layers=%d (%lld ms)\n",
             transformer_.get_config().hidden_size, transformer_.get_config().n_layers,
             (long long)(get_time_ms() - t_transformer_start));
@@ -429,8 +490,7 @@ bool Qwen3TTS::load_models(const std::string & model_dir,
         fprintf(stderr, "Loading vocoder from %s...\n", decoder_model_path_.c_str());
         int64_t t_decoder_start = get_time_ms();
         if (!audio_decoder_.load_model(decoder_model_path_)) {
-            error_msg_ = "Failed to load vocoder: " + audio_decoder_.get_error();
-            return false;
+            return fail_load("Failed to load vocoder: " + audio_decoder_.get_error());
         }
         decoder_loaded_ = true;
         fprintf(stderr, "  Vocoder loaded: sample_rate=%d, n_codebooks=%d (%lld ms)\n",
@@ -442,12 +502,9 @@ bool Qwen3TTS::load_models(const std::string & model_dir,
     }
     
     models_loaded_ = true;
-
-    {
-        std::lock_guard<std::mutex> lock(lifecycle_mutex_);
-        arm_idle_worker_locked();
-        start_idle_worker_locked();
-    }
+    publish_metadata_snapshot_locked(std::move(metadata));
+    arm_idle_worker_locked();
+    start_idle_worker_locked();
     
     int64_t t_end = get_time_ms();
     fprintf(stderr, "All models loaded in %lld ms\n", (long long)(t_end - t_start));
@@ -458,24 +515,49 @@ bool Qwen3TTS::load_models(const std::string & model_dir,
 
 tts_result Qwen3TTS::synthesize(const std::string & text,
                                  const tts_params & params) {
+    std::unique_lock<std::mutex> lock(lifecycle_mutex_);
     tts_result result;
     
     if (!models_loaded_) {
         result.error_msg = "Models not loaded";
         return result;
     }
+
+    const uint32_t required = static_cast<uint32_t>(residency_component::transformer) |
+        (decoder_loaded_ ? static_cast<uint32_t>(residency_component::decoder) : 0u);
+    std::string resident_error;
+    if (!ensure_runtime_resident_locked(required, resident_error)) {
+        result.error_msg = resident_error;
+        return result;
+    }
+    guarded_operation operation_guard(*this, true);
     
     // For basic synthesis without voice cloning, we use a zero speaker embedding
     // This will use the model's default voice characteristics
     std::vector<float> zero_embedding(transformer_.get_config().hidden_size, 0.0f);
     
-    return synthesize_internal(text, zero_embedding.data(), params, result);
+    return synthesize_internal_unlocked(text, zero_embedding.data(), params, result);
 }
 
 tts_result Qwen3TTS::synthesize_with_voice(const std::string & text,
                                             const std::string & reference_audio,
                                             const tts_params & params) {
+    std::unique_lock<std::mutex> lock(lifecycle_mutex_);
     tts_result result;
+
+    if (!models_loaded_) {
+        result.error_msg = "Models not loaded";
+        return result;
+    }
+
+    const uint32_t required = static_cast<uint32_t>(residency_component::transformer) |
+        static_cast<uint32_t>(residency_component::decoder);
+    std::string resident_error;
+    if (!ensure_runtime_resident_locked(required, resident_error)) {
+        result.error_msg = resident_error;
+        return result;
+    }
+    guarded_operation operation_guard(*this, true);
     
     std::vector<float> ref_samples;
     int ref_sample_rate;
@@ -492,12 +574,15 @@ tts_result Qwen3TTS::synthesize_with_voice(const std::string & text,
         ref_samples = std::move(resampled);
     }
     
-    return synthesize_with_voice(text, ref_samples.data(), (int32_t)ref_samples.size(), params);
+    return synthesize_with_voice_samples_unlocked(text, ref_samples.data(),
+                                                  (int32_t) ref_samples.size(),
+                                                  params, result);
 }
 
 tts_result Qwen3TTS::synthesize_with_voice(const std::string & text,
                                             const float * ref_samples, int32_t n_ref_samples,
                                             const tts_params & params) {
+    std::unique_lock<std::mutex> lock(lifecycle_mutex_);
     tts_result result;
     
     if (!models_loaded_) {
@@ -505,6 +590,23 @@ tts_result Qwen3TTS::synthesize_with_voice(const std::string & text,
         return result;
     }
 
+    const uint32_t required = static_cast<uint32_t>(residency_component::transformer) |
+        static_cast<uint32_t>(residency_component::decoder);
+    std::string resident_error;
+    if (!ensure_runtime_resident_locked(required, resident_error)) {
+        result.error_msg = resident_error;
+        return result;
+    }
+    guarded_operation operation_guard(*this, true);
+
+    return synthesize_with_voice_samples_unlocked(text, ref_samples, n_ref_samples, params, result);
+}
+
+tts_result Qwen3TTS::synthesize_with_voice_samples_unlocked(const std::string & text,
+                                                             const float * ref_samples,
+                                                             int32_t n_ref_samples,
+                                                             const tts_params & params,
+                                                             tts_result & result) {
     if (!encoder_loaded_) {
         if (tts_model_path_.empty()) {
             result.error_msg = "Internal error: missing TTS model path for lazy encoder load";
@@ -568,21 +670,36 @@ tts_result Qwen3TTS::synthesize_with_voice(const std::string & text,
         if (params.print_progress) {
             fprintf(stderr, "Reference codes: %d frames x 16 codebooks (ICL mode)\n", n_ref_frames);
         }
-        return synthesize_internal(text, speaker_embedding.data(), params, result,
-                                   ref_codes.data(), n_ref_frames);
+        return synthesize_internal_unlocked(text, speaker_embedding.data(), params, result,
+                                            ref_codes.data(), n_ref_frames);
     }
 
-    return synthesize_internal(text, speaker_embedding.data(), params, result);
+    return synthesize_internal_unlocked(text, speaker_embedding.data(), params, result);
 }
 
 bool Qwen3TTS::extract_speaker_embedding(const float * ref_samples, int32_t n_ref_samples,
                                           std::vector<float> & embedding,
                                           const tts_params & params) {
+    std::unique_lock<std::mutex> lock(lifecycle_mutex_);
     if (!models_loaded_) {
         error_msg_ = "Models not loaded";
         return false;
     }
 
+    std::string resident_error;
+    if (!ensure_runtime_resident_locked(0u, resident_error)) {
+        error_msg_ = resident_error;
+        return false;
+    }
+    guarded_operation operation_guard(*this, true);
+
+    return extract_speaker_embedding_unlocked(ref_samples, n_ref_samples, embedding, params);
+}
+
+bool Qwen3TTS::extract_speaker_embedding_unlocked(const float * ref_samples,
+                                                  int32_t n_ref_samples,
+                                                  std::vector<float> & embedding,
+                                                  const tts_params & params) {
     if (!encoder_loaded_) {
         if (tts_model_path_.empty()) {
             error_msg_ = "Internal error: missing TTS model path for lazy encoder load";
@@ -611,12 +728,22 @@ bool Qwen3TTS::extract_speaker_embedding(const float * ref_samples, int32_t n_re
 tts_result Qwen3TTS::synthesize_with_embedding(const std::string & text,
                                                 const float * embedding, int32_t embedding_size,
                                                 const tts_params & params) {
+    std::unique_lock<std::mutex> lock(lifecycle_mutex_);
     tts_result result;
 
     if (!models_loaded_) {
         result.error_msg = "Models not loaded";
         return result;
     }
+
+    const uint32_t required = static_cast<uint32_t>(residency_component::transformer) |
+        static_cast<uint32_t>(residency_component::decoder);
+    std::string resident_error;
+    if (!ensure_runtime_resident_locked(required, resident_error)) {
+        result.error_msg = resident_error;
+        return result;
+    }
+    guarded_operation operation_guard(*this, true);
 
     if (embedding == nullptr || embedding_size <= 0) {
         result.error_msg = "Invalid speaker embedding";
@@ -631,15 +758,15 @@ tts_result Qwen3TTS::synthesize_with_embedding(const std::string & text,
         return result;
     }
 
-    return synthesize_internal(text, embedding, params, result);
+    return synthesize_internal_unlocked(text, embedding, params, result);
 }
 
-tts_result Qwen3TTS::synthesize_internal(const std::string & text,
-                                          const float * speaker_embedding,
-                                          const tts_params & params,
-                                          tts_result & result,
-                                          const int32_t * ref_codes,
-                                          int32_t n_ref_frames) {
+tts_result Qwen3TTS::synthesize_internal_unlocked(const std::string & text,
+                                                   const float * speaker_embedding,
+                                                   const tts_params & params,
+                                                   tts_result & result,
+                                                   const int32_t * ref_codes,
+                                                   int32_t n_ref_frames) {
     int64_t t_total_start = get_time_ms();
     auto sample_memory = [&](const char * stage) {
         process_memory_snapshot mem;
@@ -859,45 +986,92 @@ void Qwen3TTS::set_progress_callback(tts_progress_callback_t callback) {
 // --- Model metadata & speaker-preset accessors ------------------------------
 
 const std::string & Qwen3TTS::get_model_type() const {
-    return transformer_.get_config().model_type;
+    std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+    return metadata_snapshot_locked().model_type;
 }
 
 const std::string & Qwen3TTS::get_model_size() const {
-    return transformer_.get_config().model_size;
+    std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+    return metadata_snapshot_locked().model_size;
 }
 
 bool Qwen3TTS::has_speaker_encoder() const {
-    return transformer_.get_config().has_speaker_encoder;
+    std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+    return metadata_snapshot_locked().has_speaker_encoder;
 }
 
 const std::vector<std::string> & Qwen3TTS::get_speaker_names() const {
-    return transformer_.get_config().speaker_names;
+    std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+    return metadata_snapshot_locked().speaker_names;
 }
 
 const std::vector<int32_t> & Qwen3TTS::get_speaker_ids() const {
-    return transformer_.get_config().speaker_ids;
+    std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+    return metadata_snapshot_locked().speaker_ids;
 }
 
 const std::vector<std::string> & Qwen3TTS::get_speaker_dialects() const {
-    return transformer_.get_config().speaker_dialects;
+    std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+    return metadata_snapshot_locked().speaker_dialects;
 }
 
 int32_t Qwen3TTS::get_speaker_id(const std::string & name) const {
-    const auto & cfg = transformer_.get_config();
-    for (size_t i = 0; i < cfg.speaker_names.size(); ++i) {
-        if (cfg.speaker_names[i] == name) {
-            return cfg.speaker_ids[i];
+    std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+    const auto & metadata = metadata_snapshot_locked();
+    for (size_t i = 0; i < metadata.speaker_names.size(); ++i) {
+        if (metadata.speaker_names[i] == name) {
+            return metadata.speaker_ids[i];
         }
     }
     return -1;
 }
 
+bool Qwen3TTS::is_loaded() const {
+    std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+    return models_loaded_;
+}
+
 bool Qwen3TTS::get_speaker_embedding(const std::string & name, std::vector<float> & out) {
-    int32_t tid = get_speaker_id(name);
+    std::unique_lock<std::mutex> lock(lifecycle_mutex_);
+
+    if (!models_loaded_) {
+        error_msg_ = "Models not loaded";
+        return false;
+    }
+
+    if (!transformer_loaded_) {
+        if (tts_model_path_.empty()) {
+            error_msg_ = "Internal error: missing TTS model path for transformer reload";
+            return false;
+        }
+        if (!transformer_.load_model(tts_model_path_)) {
+            error_msg_ = "Failed to reload TTS transformer: " + transformer_.get_error();
+            return false;
+        }
+        transformer_loaded_ = true;
+    }
+
+    const auto & cfg = metadata_snapshot_locked();
+    int32_t tid = -1;
+    for (size_t i = 0; i < cfg.speaker_names.size(); ++i) {
+        if (cfg.speaker_names[i] == name) {
+            tid = cfg.speaker_ids[i];
+            break;
+        }
+    }
     if (tid < 0) {
         error_msg_ = "Unknown speaker preset: " + name;
         return false;
     }
+
+    std::string resident_error;
+    if (!ensure_runtime_resident_locked(static_cast<uint32_t>(residency_component::transformer),
+                                        resident_error)) {
+        error_msg_ = resident_error;
+        return false;
+    }
+    guarded_operation operation_guard(*this, true);
+
     if (!transformer_.get_codec_embedding_row(tid, out)) {
         error_msg_ = "Failed to read codec_embd row: " + transformer_.get_error();
         return false;

--- a/src/pipeline/qwen3_tts.cpp
+++ b/src/pipeline/qwen3_tts.cpp
@@ -234,7 +234,19 @@ bool Qwen3TTS::offload_idle_components_locked(bool force_for_test, std::string *
 
     if (transformer_loaded_ && !transformer_.is_ram_offloaded()) {
         std::string component_error;
-        if (force_for_test || transformer_.can_offload_to_ram()) {
+        if (force_for_test) {
+            if (transformer_.offload_weights_to_ram(component_error, false)) {
+                fprintf(stderr, "  GPU idle RAM offload: transformer copied %s to host RAM\n",
+                        format_bytes((uint64_t) transformer_.ram_offloaded_bytes()).c_str());
+            } else {
+                ok = false;
+                fprintf(stderr, "  WARNING: GPU idle RAM offload failed for transformer: %s\n",
+                        component_error.c_str());
+                if (error && error->empty()) {
+                    *error = "Transformer idle RAM offload failed: " + component_error;
+                }
+            }
+        } else if (transformer_.can_offload_to_ram()) {
             if (transformer_.offload_weights_to_ram(component_error)) {
                 fprintf(stderr, "  GPU idle RAM offload: transformer copied %s to host RAM\n",
                         format_bytes((uint64_t) transformer_.ram_offloaded_bytes()).c_str());
@@ -254,7 +266,19 @@ bool Qwen3TTS::offload_idle_components_locked(bool force_for_test, std::string *
 
     if (decoder_loaded_ && !audio_decoder_.is_ram_offloaded()) {
         std::string component_error;
-        if (force_for_test || audio_decoder_.can_offload_to_ram()) {
+        if (force_for_test) {
+            if (audio_decoder_.offload_weights_to_ram(component_error, false)) {
+                fprintf(stderr, "  GPU idle RAM offload: decoder copied %s to host RAM\n",
+                        format_bytes((uint64_t) audio_decoder_.ram_offloaded_bytes()).c_str());
+            } else {
+                ok = false;
+                fprintf(stderr, "  WARNING: GPU idle RAM offload failed for decoder: %s\n",
+                        component_error.c_str());
+                if (error && error->empty()) {
+                    *error = "Decoder idle RAM offload failed: " + component_error;
+                }
+            }
+        } else if (audio_decoder_.can_offload_to_ram()) {
             if (audio_decoder_.offload_weights_to_ram(component_error)) {
                 fprintf(stderr, "  GPU idle RAM offload: decoder copied %s to host RAM\n",
                         format_bytes((uint64_t) audio_decoder_.ram_offloaded_bytes()).c_str());
@@ -282,7 +306,7 @@ bool Qwen3TTS::force_transformer_offload_for_test(std::string & error) {
         error = "Cannot force transformer RAM offload: transformer is not loaded";
         return false;
     }
-    return transformer_.offload_weights_to_ram(error);
+    return transformer_.offload_weights_to_ram(error, false);
 }
 
 bool Qwen3TTS::transformer_ram_offloaded_for_test() const {

--- a/src/pipeline/qwen3_tts.cpp
+++ b/src/pipeline/qwen3_tts.cpp
@@ -1,5 +1,6 @@
 #include "pipeline/qwen3_tts.h"
 #include "common/gguf_loader.h"
+#include "common/gpu_offload_policy.h"
 
 #include <cstdio>
 #include <cstring>
@@ -114,13 +115,198 @@ static void resample_linear(const float * input, int input_len, int input_rate,
 
 Qwen3TTS::Qwen3TTS() = default;
 
-Qwen3TTS::~Qwen3TTS() = default;
+Qwen3TTS::~Qwen3TTS() {
+    stop_idle_worker();
+}
+
+bool Qwen3TTS::ensure_runtime_resident_locked(uint32_t required, std::string & error) {
+    ++idle_generation_;
+
+    const uint32_t transformer_mask = static_cast<uint32_t>(residency_component::transformer);
+    if ((required & transformer_mask) != 0 && transformer_loaded_ && transformer_.is_ram_offloaded()) {
+        if (!transformer_.reload_weights_from_ram(error)) {
+            if (error.empty()) {
+                error = "Failed to reload RAM-offloaded transformer weights";
+            }
+            return false;
+        }
+    }
+
+    const uint32_t decoder_mask = static_cast<uint32_t>(residency_component::decoder);
+    if ((required & decoder_mask) != 0 && decoder_loaded_ && audio_decoder_.is_ram_offloaded()) {
+        if (!audio_decoder_.reload_weights_from_ram(error)) {
+            if (error.empty()) {
+                error = "Failed to reload RAM-offloaded decoder weights";
+            }
+            return false;
+        }
+    }
+
+    operation_active_ = true;
+    return true;
+}
+
+void Qwen3TTS::finish_guarded_operation_locked() {
+    operation_active_ = false;
+    ++idle_generation_;
+    if (gpu_idle_offload_enabled_) {
+        idle_cv_.notify_all();
+    }
+}
+
+void Qwen3TTS::arm_idle_worker_locked() {
+    if (!gpu_idle_offload_enabled_) {
+        return;
+    }
+    ++idle_generation_;
+    idle_cv_.notify_all();
+}
+
+void Qwen3TTS::start_idle_worker_locked() {
+    if (!gpu_idle_offload_enabled_ || idle_worker_.joinable()) {
+        return;
+    }
+    idle_worker_shutdown_ = false;
+    idle_worker_ = std::thread(&Qwen3TTS::idle_worker_main, this);
+}
+
+void Qwen3TTS::stop_idle_worker() {
+    {
+        std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+        idle_worker_shutdown_ = true;
+        ++idle_generation_;
+        idle_cv_.notify_all();
+    }
+
+    if (idle_worker_.joinable()) {
+        idle_worker_.join();
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+        idle_worker_shutdown_ = false;
+        operation_active_ = false;
+        ++idle_generation_;
+    }
+}
+
+void Qwen3TTS::idle_worker_main() {
+    std::unique_lock<std::mutex> lock(lifecycle_mutex_);
+
+    for (;;) {
+        idle_cv_.wait(lock, [this] {
+            return idle_worker_shutdown_ ||
+                   (gpu_idle_offload_enabled_ && !operation_active_);
+        });
+
+        if (idle_worker_shutdown_) {
+            return;
+        }
+        if (!gpu_idle_offload_enabled_ || operation_active_ || gpu_offload_idle_secs_ <= 0) {
+            continue;
+        }
+
+        const uint64_t generation = idle_generation_;
+        const auto idle_timeout = std::chrono::seconds(gpu_offload_idle_secs_);
+        idle_cv_.wait_for(lock, idle_timeout);
+
+        if (idle_worker_shutdown_) {
+            return;
+        }
+        if (!gpu_idle_offload_enabled_ || operation_active_ ||
+            idle_generation_ != generation || gpu_offload_idle_secs_ <= 0) {
+            continue;
+        }
+
+        offload_idle_components_locked(false);
+    }
+}
+
+bool Qwen3TTS::offload_idle_components_locked(bool force_for_test, std::string * error) {
+    bool ok = true;
+    if (error) {
+        error->clear();
+    }
+
+    if (!transformer_loaded_ && !decoder_loaded_) {
+        return true;
+    }
+
+    if (transformer_loaded_ && !transformer_.is_ram_offloaded()) {
+        std::string component_error;
+        if (force_for_test || transformer_.can_offload_to_ram()) {
+            if (transformer_.offload_weights_to_ram(component_error)) {
+                fprintf(stderr, "  GPU idle RAM offload: transformer copied %s to host RAM\n",
+                        format_bytes((uint64_t) transformer_.ram_offloaded_bytes()).c_str());
+            } else {
+                ok = false;
+                fprintf(stderr, "  WARNING: GPU idle RAM offload failed for transformer: %s\n",
+                        component_error.c_str());
+                if (error && error->empty()) {
+                    *error = "Transformer idle RAM offload failed: " + component_error;
+                }
+            }
+        } else if (gpu_idle_offload_enabled_ && !logged_transformer_offload_ineligible_) {
+            fprintf(stderr, "  GPU idle RAM offload: transformer not eligible on this backend/current state\n");
+            logged_transformer_offload_ineligible_ = true;
+        }
+    }
+
+    if (decoder_loaded_ && !audio_decoder_.is_ram_offloaded()) {
+        std::string component_error;
+        if (force_for_test || audio_decoder_.can_offload_to_ram()) {
+            if (audio_decoder_.offload_weights_to_ram(component_error)) {
+                fprintf(stderr, "  GPU idle RAM offload: decoder copied %s to host RAM\n",
+                        format_bytes((uint64_t) audio_decoder_.ram_offloaded_bytes()).c_str());
+            } else {
+                ok = false;
+                fprintf(stderr, "  WARNING: GPU idle RAM offload failed for decoder: %s\n",
+                        component_error.c_str());
+                if (error && error->empty()) {
+                    *error = "Decoder idle RAM offload failed: " + component_error;
+                }
+            }
+        } else if (gpu_idle_offload_enabled_ && !logged_decoder_offload_ineligible_) {
+            fprintf(stderr, "  GPU idle RAM offload: decoder not eligible on this backend/current state\n");
+            logged_decoder_offload_ineligible_ = true;
+        }
+    }
+
+    return ok;
+}
+
+bool Qwen3TTS::force_transformer_offload_for_test(std::string & error) {
+    std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+    ++idle_generation_;
+    if (!transformer_loaded_) {
+        error = "Cannot force transformer RAM offload: transformer is not loaded";
+        return false;
+    }
+    return transformer_.offload_weights_to_ram(error);
+}
+
+bool Qwen3TTS::transformer_ram_offloaded_for_test() const {
+    std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+    return transformer_.is_ram_offloaded();
+}
+
+bool Qwen3TTS::force_idle_offload_once_for_test(std::string & error) {
+    std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+    if (operation_active_) {
+        error = "Cannot force idle RAM offload while an operation is active";
+        return false;
+    }
+    ++idle_generation_;
+    return offload_idle_components_locked(true, &error);
+}
 
 bool Qwen3TTS::load_models(const std::string & model_dir,
                            const std::string & tts_model,
                            const std::string & tokenizer_model) {
     int64_t t_start = get_time_ms();
     log_memory_usage("load/start");
+
+    stop_idle_worker();
 
     transformer_.unload_model();
     audio_decoder_.unload_model();
@@ -156,6 +342,16 @@ bool Qwen3TTS::load_models(const std::string & model_dir,
     if (low_mem_mode_) {
         fprintf(stderr, "  Low-memory mode enabled (lazy decoder + component unloads)\n");
     }
+
+    auto policy = parse_gpu_offload_policy(std::getenv("QWEN3_TTS_GPU_OFFLOAD_IDLE_SECS"),
+                                           low_mem_mode_);
+    gpu_idle_offload_enabled_ = policy.enabled;
+    gpu_offload_idle_secs_ = policy.idle_secs;
+    logged_transformer_offload_ineligible_ = false;
+    logged_decoder_offload_ineligible_ = false;
+    fprintf(stderr, "  GPU idle RAM offload: %s (%s)\n",
+            gpu_idle_offload_enabled_ ? "enabled" : "disabled",
+            policy.reason.c_str());
     
     // Load TTS model (contains text tokenizer + transformer for generation)
     fprintf(stderr, "Loading TTS model from %s...\n", tts_model_path_.c_str());
@@ -212,6 +408,12 @@ bool Qwen3TTS::load_models(const std::string & model_dir,
     }
     
     models_loaded_ = true;
+
+    {
+        std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+        arm_idle_worker_locked();
+        start_idle_worker_locked();
+    }
     
     int64_t t_end = get_time_ms();
     fprintf(stderr, "All models loaded in %lld ms\n", (long long)(t_end - t_start));

--- a/src/pipeline/qwen3_tts.h
+++ b/src/pipeline/qwen3_tts.h
@@ -7,6 +7,7 @@
 #include "decoder/audio_tokenizer_decoder.h"
 
 #include <condition_variable>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -189,9 +190,10 @@ public:
     const std::string & get_error() const { return error_msg_; }
 
     // Check if models are loaded
-    bool is_loaded() const { return models_loaded_; }
+    bool is_loaded() const;
     
 private:
+    friend class guarded_operation;
 #ifdef QWEN3_TTS_ENABLE_TEST_DIAGNOSTICS
     friend class Qwen3TTSDiagnostics;
 #endif
@@ -202,23 +204,44 @@ private:
         decoder = 1u << 1,
     };
 
-    tts_result synthesize_internal(const std::string & text,
-                                   const float * speaker_embedding,
-                                   const tts_params & params,
-                                   tts_result & result,
-                                   const int32_t * ref_codes = nullptr,
-                                   int32_t n_ref_frames = 0);
+    struct model_metadata_snapshot {
+        std::string model_type;
+        std::string model_size;
+        bool has_speaker_encoder = false;
+        std::vector<std::string> speaker_names;
+        std::vector<int32_t> speaker_ids;
+        std::vector<std::string> speaker_dialects;
+    };
+
+    tts_result synthesize_with_voice_samples_unlocked(const std::string & text,
+                                                      const float * ref_samples,
+                                                      int32_t n_ref_samples,
+                                                      const tts_params & params,
+                                                      tts_result & result);
+    tts_result synthesize_internal_unlocked(const std::string & text,
+                                            const float * speaker_embedding,
+                                            const tts_params & params,
+                                            tts_result & result,
+                                            const int32_t * ref_codes = nullptr,
+                                            int32_t n_ref_frames = 0);
+    bool extract_speaker_embedding_unlocked(const float * ref_samples,
+                                            int32_t n_ref_samples,
+                                            std::vector<float> & embedding,
+                                            const tts_params & params);
 
     bool ensure_runtime_resident_locked(uint32_t required, std::string & error);
     void finish_guarded_operation_locked();
     void arm_idle_worker_locked();
     void start_idle_worker_locked();
+    void stop_idle_worker_locked(std::unique_lock<std::mutex> & lock);
     void stop_idle_worker();
     void idle_worker_main();
     bool offload_idle_components_locked(bool force_for_test = false, std::string * error = nullptr);
     bool force_transformer_offload_for_test(std::string & error);
     bool transformer_ram_offloaded_for_test() const;
     bool force_idle_offload_once_for_test(std::string & error);
+    void publish_metadata_snapshot_locked(std::shared_ptr<const model_metadata_snapshot> snapshot);
+    const model_metadata_snapshot & metadata_snapshot_locked() const;
 
     TextTokenizer tokenizer_;
     TTSTransformer transformer_;
@@ -236,7 +259,10 @@ private:
     std::string tts_model_path_;
     std::string decoder_model_path_;
     tts_progress_callback_t progress_callback_;
+    std::shared_ptr<const model_metadata_snapshot> metadata_snapshot_;
+    std::vector<std::shared_ptr<const model_metadata_snapshot>> retained_metadata_snapshots_;
 
+    std::mutex reload_mutex_;
     mutable std::mutex lifecycle_mutex_;
     std::condition_variable idle_cv_;
     std::thread idle_worker_;

--- a/src/pipeline/qwen3_tts.h
+++ b/src/pipeline/qwen3_tts.h
@@ -6,7 +6,10 @@
 #include "encoder/audio_codec_encoder.h"
 #include "decoder/audio_tokenizer_decoder.h"
 
+#include <condition_variable>
+#include <mutex>
 #include <string>
+#include <thread>
 #include <vector>
 #include <functional>
 #include <cstdint>
@@ -174,14 +177,32 @@ public:
 
     // Check if models are loaded
     bool is_loaded() const { return models_loaded_; }
+
+    bool force_transformer_offload_for_test(std::string & error);
+    bool transformer_ram_offloaded_for_test() const;
+    bool force_idle_offload_once_for_test(std::string & error);
     
 private:
+    enum class residency_component : uint32_t {
+        none = 0,
+        transformer = 1u << 0,
+        decoder = 1u << 1,
+    };
+
     tts_result synthesize_internal(const std::string & text,
                                    const float * speaker_embedding,
                                    const tts_params & params,
                                    tts_result & result,
                                    const int32_t * ref_codes = nullptr,
                                    int32_t n_ref_frames = 0);
+
+    bool ensure_runtime_resident_locked(uint32_t required, std::string & error);
+    void finish_guarded_operation_locked();
+    void arm_idle_worker_locked();
+    void start_idle_worker_locked();
+    void stop_idle_worker();
+    void idle_worker_main();
+    bool offload_idle_components_locked(bool force_for_test = false, std::string * error = nullptr);
 
     TextTokenizer tokenizer_;
     TTSTransformer transformer_;
@@ -199,6 +220,17 @@ private:
     std::string tts_model_path_;
     std::string decoder_model_path_;
     tts_progress_callback_t progress_callback_;
+
+    mutable std::mutex lifecycle_mutex_;
+    std::condition_variable idle_cv_;
+    std::thread idle_worker_;
+    bool idle_worker_shutdown_ = false;
+    bool operation_active_ = false;
+    uint64_t idle_generation_ = 0;
+    int gpu_offload_idle_secs_ = 0;
+    bool gpu_idle_offload_enabled_ = false;
+    bool logged_transformer_offload_ineligible_ = false;
+    bool logged_decoder_offload_ineligible_ = false;
 };
 
 // Utility: Load audio file (WAV format)

--- a/src/pipeline/qwen3_tts.h
+++ b/src/pipeline/qwen3_tts.h
@@ -16,6 +16,19 @@
 
 namespace qwen3_tts {
 
+class Qwen3TTS;
+
+#ifdef QWEN3_TTS_ENABLE_TEST_DIAGNOSTICS
+// Opt-in C++ diagnostics for deterministic lifecycle tests. These are not
+// exposed through the C API or Python bindings.
+class Qwen3TTSDiagnostics {
+public:
+    static bool force_transformer_offload(Qwen3TTS & tts, std::string & error);
+    static bool transformer_ram_offloaded(const Qwen3TTS & tts);
+    static bool force_idle_offload_once(Qwen3TTS & tts, std::string & error);
+};
+#endif
+
 // TTS generation parameters
 struct tts_params {
     // Maximum number of audio tokens to generate
@@ -177,12 +190,12 @@ public:
 
     // Check if models are loaded
     bool is_loaded() const { return models_loaded_; }
-
-    bool force_transformer_offload_for_test(std::string & error);
-    bool transformer_ram_offloaded_for_test() const;
-    bool force_idle_offload_once_for_test(std::string & error);
     
 private:
+#ifdef QWEN3_TTS_ENABLE_TEST_DIAGNOSTICS
+    friend class Qwen3TTSDiagnostics;
+#endif
+
     enum class residency_component : uint32_t {
         none = 0,
         transformer = 1u << 0,
@@ -203,6 +216,9 @@ private:
     void stop_idle_worker();
     void idle_worker_main();
     bool offload_idle_components_locked(bool force_for_test = false, std::string * error = nullptr);
+    bool force_transformer_offload_for_test(std::string & error);
+    bool transformer_ram_offloaded_for_test() const;
+    bool force_idle_offload_once_for_test(std::string & error);
 
     TextTokenizer tokenizer_;
     TTSTransformer transformer_;
@@ -225,13 +241,27 @@ private:
     std::condition_variable idle_cv_;
     std::thread idle_worker_;
     bool idle_worker_shutdown_ = false;
-    bool operation_active_ = false;
+    uint32_t active_operations_ = 0;
     uint64_t idle_generation_ = 0;
     int gpu_offload_idle_secs_ = 0;
     bool gpu_idle_offload_enabled_ = false;
     bool logged_transformer_offload_ineligible_ = false;
     bool logged_decoder_offload_ineligible_ = false;
 };
+
+#ifdef QWEN3_TTS_ENABLE_TEST_DIAGNOSTICS
+inline bool Qwen3TTSDiagnostics::force_transformer_offload(Qwen3TTS & tts, std::string & error) {
+    return tts.force_transformer_offload_for_test(error);
+}
+
+inline bool Qwen3TTSDiagnostics::transformer_ram_offloaded(const Qwen3TTS & tts) {
+    return tts.transformer_ram_offloaded_for_test();
+}
+
+inline bool Qwen3TTSDiagnostics::force_idle_offload_once(Qwen3TTS & tts, std::string & error) {
+    return tts.force_idle_offload_once_for_test(error);
+}
+#endif
 
 // Utility: Load audio file (WAV format)
 bool load_audio_file(const std::string & path, std::vector<float> & samples, 

--- a/src/pipeline/qwen3_tts.h
+++ b/src/pipeline/qwen3_tts.h
@@ -26,6 +26,7 @@ class Qwen3TTSDiagnostics {
 public:
     static bool force_transformer_offload(Qwen3TTS & tts, std::string & error);
     static bool transformer_ram_offloaded(const Qwen3TTS & tts);
+    static bool decoder_ram_offloaded(const Qwen3TTS & tts);
     static bool force_idle_offload_once(Qwen3TTS & tts, std::string & error);
 };
 #endif
@@ -239,6 +240,7 @@ private:
     bool offload_idle_components_locked(bool force_for_test = false, std::string * error = nullptr);
     bool force_transformer_offload_for_test(std::string & error);
     bool transformer_ram_offloaded_for_test() const;
+    bool decoder_ram_offloaded_for_test() const;
     bool force_idle_offload_once_for_test(std::string & error);
     void publish_metadata_snapshot_locked(std::shared_ptr<const model_metadata_snapshot> snapshot);
     const model_metadata_snapshot & metadata_snapshot_locked() const;
@@ -282,6 +284,10 @@ inline bool Qwen3TTSDiagnostics::force_transformer_offload(Qwen3TTS & tts, std::
 
 inline bool Qwen3TTSDiagnostics::transformer_ram_offloaded(const Qwen3TTS & tts) {
     return tts.transformer_ram_offloaded_for_test();
+}
+
+inline bool Qwen3TTSDiagnostics::decoder_ram_offloaded(const Qwen3TTS & tts) {
+    return tts.decoder_ram_offloaded_for_test();
 }
 
 inline bool Qwen3TTSDiagnostics::force_idle_offload_once(Qwen3TTS & tts, std::string & error) {

--- a/src/transformer/tts_transformer.cpp
+++ b/src/transformer/tts_transformer.cpp
@@ -190,6 +190,10 @@ bool TTSTransformer::can_offload_to_ram() const {
 }
 
 bool TTSTransformer::offload_weights_to_ram(std::string & error) {
+    return offload_weights_to_ram(error, true);
+}
+
+bool TTSTransformer::offload_weights_to_ram(std::string & error, bool require_supported_backend) {
     error.clear();
 
     if (model_.residency == weight_residency::RamResident) {
@@ -203,7 +207,7 @@ bool TTSTransformer::offload_weights_to_ram(std::string & error) {
         error = "Cannot offload transformer weights: model buffer is null";
         return false;
     }
-    if (!can_offload_to_ram()) {
+    if (require_supported_backend && !can_offload_to_ram()) {
         error = "Cannot offload transformer weights: backend does not support RAM offload";
         return false;
     }

--- a/src/transformer/tts_transformer.cpp
+++ b/src/transformer/tts_transformer.cpp
@@ -291,6 +291,14 @@ size_t TTSTransformer::ram_offloaded_bytes() const {
     return model_.host_weights.total_bytes;
 }
 
+bool TTSTransformer::require_weights_gpu_resident() {
+    if (model_.residency == weight_residency::RamResident) {
+        error_msg_ = "Transformer weights are RAM-offloaded; reload_weights_from_ram() first";
+        return false;
+    }
+    return true;
+}
+
 bool TTSTransformer::try_init_coreml_code_predictor(const std::string & model_path) {
     use_coreml_code_predictor_ = false;
     coreml_code_predictor_path_.clear();
@@ -902,6 +910,10 @@ bool TTSTransformer::load_tensor_data(const std::string & path, struct gguf_cont
 }
 
 bool TTSTransformer::init_kv_cache(int32_t n_ctx) {
+    if (!require_weights_gpu_resident()) {
+        return false;
+    }
+
     const auto & cfg = model_.config;
     
     free_tts_kv_cache(state_.cache);
@@ -956,6 +968,10 @@ void TTSTransformer::clear_kv_cache() {
 }
 
 bool TTSTransformer::init_code_pred_kv_cache(int32_t n_ctx) {
+    if (!require_weights_gpu_resident()) {
+        return false;
+    }
+
     const auto & cfg = model_.config;
     
     free_tts_kv_cache(state_.code_pred_cache);
@@ -1134,6 +1150,10 @@ bool TTSTransformer::lookup_single_embedding_row(struct ggml_tensor * embedding,
 }
 
 bool TTSTransformer::get_codec_embedding_row(int32_t token_id, std::vector<float> & out) {
+    if (!require_weights_gpu_resident()) {
+        return false;
+    }
+
     if (!model_.codec_embd) {
         error_msg_ = "codec_embd tensor not loaded";
         return false;
@@ -2217,6 +2237,10 @@ struct ggml_cgraph * TTSTransformer::build_code_pred_step_graph(int32_t n_past, 
 bool TTSTransformer::forward_prefill(const float * prefill_embd, int32_t n_tokens,
                                      int32_t n_past, std::vector<float> & output,
                                      std::vector<float> * logits_out) {
+    if (!require_weights_gpu_resident()) {
+        return false;
+    }
+
     if (!model_.ctx) {
         error_msg_ = "Model not loaded";
         return false;
@@ -2349,6 +2373,10 @@ bool TTSTransformer::forward_prefill(const float * prefill_embd, int32_t n_token
 bool TTSTransformer::forward_text(const int32_t * text_tokens, int32_t n_tokens,
                                   const float * speaker_embd, int32_t n_past,
                                   std::vector<float> & output) {
+    if (!require_weights_gpu_resident()) {
+        return false;
+    }
+
     if (!text_tokens) {
         error_msg_ = "text_tokens is null";
         return false;
@@ -2379,6 +2407,10 @@ bool TTSTransformer::forward_text(const int32_t * text_tokens, int32_t n_tokens,
 bool TTSTransformer::forward_step(const float * step_embd, int32_t n_past,
                                   std::vector<float> & output,
                                   std::vector<float> * hidden_out) {
+    if (!require_weights_gpu_resident()) {
+        return false;
+    }
+
     if (!model_.ctx) {
         error_msg_ = "Model not loaded";
         return false;
@@ -2495,6 +2527,10 @@ bool TTSTransformer::forward_step(const float * step_embd, int32_t n_past,
 
 bool TTSTransformer::forward_codec(int32_t codec_token, int32_t n_past,
                                    std::vector<float> & output) {
+    if (!require_weights_gpu_resident()) {
+        return false;
+    }
+
     std::vector<float> codec_row;
     if (!lookup_embedding_rows(model_.codec_embd, &codec_token, 1,
                                "inp_legacy_codec_token", "legacy_codec_row",
@@ -2515,6 +2551,10 @@ bool TTSTransformer::get_hidden_states(std::vector<float> & hidden) const {
 
 bool TTSTransformer::predict_codes(const float * hidden, const int32_t * prev_codes,
                                     std::vector<float> & output) {
+    if (!require_weights_gpu_resident()) {
+        return false;
+    }
+
     if (!model_.ctx) {
         error_msg_ = "Model not loaded";
         return false;
@@ -2696,6 +2736,10 @@ bool TTSTransformer::predict_codes_autoregressive_coreml(const float * hidden,
 bool TTSTransformer::predict_codes_autoregressive(const float * hidden, int32_t codebook_0_token,
                                                    std::vector<int32_t> & output,
                                                    float temperature, int32_t top_k) {
+    if (!require_weights_gpu_resident()) {
+        return false;
+    }
+
     if (!model_.ctx) {
         error_msg_ = "Model not loaded";
         return false;
@@ -2971,6 +3015,10 @@ bool TTSTransformer::generate(const int32_t * text_tokens, int32_t n_tokens,
                                int32_t n_ref_text_tokens,
                                const int32_t * ref_codes,
                                int32_t n_ref_frames) {
+    if (!require_weights_gpu_resident()) {
+        return false;
+    }
+
 #ifdef QWEN3_TTS_TIMING
     using clk = std::chrono::high_resolution_clock;
     tts_timing timing = {};

--- a/src/transformer/tts_transformer.cpp
+++ b/src/transformer/tts_transformer.cpp
@@ -15,6 +15,40 @@
 
 namespace qwen3_tts {
 
+namespace {
+
+bool create_transformer_scheduler(tts_transformer_state & state, std::string & error) {
+    std::vector<ggml_backend_t> backends;
+    backends.push_back(state.backend);
+    if (state.backend_cpu) {
+        backends.push_back(state.backend_cpu);
+    }
+
+    state.sched = ggml_backend_sched_new(backends.data(), nullptr, (int) backends.size(),
+                                         QWEN3_TTS_MAX_NODES, false, true);
+    if (!state.sched) {
+        error = "Failed to create backend scheduler";
+        return false;
+    }
+    return true;
+}
+
+void clear_context_tensor_allocations(ggml_context * ctx) {
+    if (!ctx) {
+        return;
+    }
+
+    for (ggml_tensor * tensor = ggml_get_first_tensor(ctx);
+         tensor;
+         tensor = ggml_get_next_tensor(ctx, tensor)) {
+        tensor->buffer = nullptr;
+        tensor->data = nullptr;
+        tensor->extra = nullptr;
+    }
+}
+
+} // namespace
+
 TTSTransformer::TTSTransformer() = default;
 
 TTSTransformer::~TTSTransformer() {
@@ -136,14 +170,7 @@ bool TTSTransformer::load_model(const std::string & model_path) {
         }
     }
     
-    std::vector<ggml_backend_t> backends;
-    backends.push_back(state_.backend);
-    if (state_.backend_cpu) {
-        backends.push_back(state_.backend_cpu);
-    }
-    state_.sched = ggml_backend_sched_new(backends.data(), nullptr, (int)backends.size(), QWEN3_TTS_MAX_NODES, false, true);
-    if (!state_.sched) {
-        error_msg_ = "Failed to create backend scheduler";
+    if (!create_transformer_scheduler(state_, error_msg_)) {
         return false;
     }
     
@@ -154,6 +181,114 @@ bool TTSTransformer::load_model(const std::string & model_path) {
     }
     
     return true;
+}
+
+bool TTSTransformer::can_offload_to_ram() const {
+    return model_.residency == weight_residency::GpuResident &&
+           model_.buffer != nullptr &&
+           backend_is_cuda_or_vulkan(state_.backend);
+}
+
+bool TTSTransformer::offload_weights_to_ram(std::string & error) {
+    error.clear();
+
+    if (model_.residency == weight_residency::RamResident) {
+        return true;
+    }
+    if (model_.residency != weight_residency::GpuResident) {
+        error = "Cannot offload transformer weights: model weights are not GPU-resident";
+        return false;
+    }
+    if (!model_.buffer) {
+        error = "Cannot offload transformer weights: model buffer is null";
+        return false;
+    }
+    if (!can_offload_to_ram()) {
+        error = "Cannot offload transformer weights: backend does not support RAM offload";
+        return false;
+    }
+
+    free_tts_kv_cache(state_.cache);
+    free_tts_kv_cache(state_.code_pred_cache);
+    if (state_.sched) {
+        ggml_backend_sched_reset(state_.sched);
+    }
+
+    if (!download_tensors_to_host(model_.tensors, model_.host_weights, error)) {
+        model_.host_weights.clear();
+        model_.residency = weight_residency::GpuResident;
+        return false;
+    }
+
+    if (state_.sched) {
+        ggml_backend_sched_free(state_.sched);
+        state_.sched = nullptr;
+    }
+    ggml_backend_buffer_free(model_.buffer);
+    model_.buffer = nullptr;
+    clear_context_tensor_allocations(model_.ctx);
+    model_.residency = weight_residency::RamResident;
+    last_hidden_.clear();
+    embd_row_fp16_scratch_.clear();
+    return true;
+}
+
+bool TTSTransformer::reload_weights_from_ram(std::string & error) {
+    error.clear();
+
+    if (model_.residency == weight_residency::GpuResident) {
+        return true;
+    }
+    if (model_.residency != weight_residency::RamResident) {
+        error = "Cannot reload transformer weights: model weights are not RAM-resident";
+        return false;
+    }
+    if (!model_.ctx) {
+        error = "Cannot reload transformer weights: ggml context is null";
+        return false;
+    }
+    if (!state_.backend) {
+        error = "Cannot reload transformer weights: backend is null";
+        return false;
+    }
+    if (model_.host_weights.tensors.empty() || model_.host_weights.total_bytes == 0) {
+        error = "Cannot reload transformer weights: host tensor store is empty";
+        return false;
+    }
+    if (model_.buffer) {
+        error = "Cannot reload transformer weights: model buffer must be null";
+        return false;
+    }
+
+    if (!upload_tensors_from_host(model_.ctx, model_.tensors, state_.backend,
+                                  model_.host_weights, model_.buffer, error)) {
+        model_.buffer = nullptr;
+        model_.residency = weight_residency::RamResident;
+        return false;
+    }
+
+    if (!state_.sched && !create_transformer_scheduler(state_, error)) {
+        ggml_backend_buffer_free(model_.buffer);
+        model_.buffer = nullptr;
+        clear_context_tensor_allocations(model_.ctx);
+        model_.residency = weight_residency::RamResident;
+        if (error.empty()) {
+            error = "Failed to recreate transformer scheduler after weight reload";
+        }
+        return false;
+    }
+
+    model_.host_weights.clear();
+    model_.residency = weight_residency::GpuResident;
+    return true;
+}
+
+bool TTSTransformer::is_ram_offloaded() const {
+    return model_.residency == weight_residency::RamResident;
+}
+
+size_t TTSTransformer::ram_offloaded_bytes() const {
+    return model_.host_weights.total_bytes;
 }
 
 bool TTSTransformer::try_init_coreml_code_predictor(const std::string & model_path) {
@@ -759,6 +894,9 @@ bool TTSTransformer::load_tensor_data(const std::string & path, struct gguf_cont
     
     fclose(f);
     release_preferred_backend(backend);
+
+    model_.host_weights.clear();
+    model_.residency = weight_residency::GpuResident;
     
     return true;
 }
@@ -3128,6 +3266,8 @@ void free_transformer_model(tts_transformer_model & model) {
         ggml_free(model.ctx);
         model.ctx = nullptr;
     }
+    model.host_weights.clear();
+    model.residency = weight_residency::Unloaded;
     model.tensors.clear();
     model.layers.clear();
     model.code_pred_layers.clear();

--- a/src/transformer/tts_transformer.h
+++ b/src/transformer/tts_transformer.h
@@ -336,6 +336,8 @@ public:
                             std::vector<float> & output);
     
 private:
+    bool require_weights_gpu_resident();
+
     bool try_init_coreml_code_predictor(const std::string & model_path);
     bool predict_codes_autoregressive_coreml(const float * hidden, int32_t codebook_0_token,
                                              std::vector<int32_t> & output,

--- a/src/transformer/tts_transformer.h
+++ b/src/transformer/tts_transformer.h
@@ -4,6 +4,7 @@
 #include "ggml-backend.h"
 #include "gguf.h"
 #include "common/coreml_code_predictor.h"
+#include "common/weight_residency.h"
 
 #include <string>
 #include <map>
@@ -180,6 +181,9 @@ struct tts_transformer_model {
     
     // Tensor name to tensor mapping
     std::map<std::string, struct ggml_tensor *> tensors;
+
+    weight_residency residency = weight_residency::Unloaded;
+    host_tensor_store host_weights;
 };
 
 // KV cache for autoregressive generation
@@ -220,6 +224,12 @@ public:
 
     // Release all model/runtime resources
     void unload_model();
+
+    bool can_offload_to_ram() const;
+    bool offload_weights_to_ram(std::string & error);
+    bool reload_weights_from_ram(std::string & error);
+    bool is_ram_offloaded() const;
+    size_t ram_offloaded_bytes() const;
     
     // Initialize KV cache
     bool init_kv_cache(int32_t n_ctx);

--- a/src/transformer/tts_transformer.h
+++ b/src/transformer/tts_transformer.h
@@ -17,6 +17,8 @@
 
 namespace qwen3_tts {
 
+class Qwen3TTS;
+
 #ifdef QWEN3_TTS_TIMING
 struct tts_timing {
     // Prefill phase
@@ -336,6 +338,9 @@ public:
                             std::vector<float> & output);
     
 private:
+    friend class Qwen3TTS;
+
+    bool offload_weights_to_ram(std::string & error, bool require_supported_backend);
     bool require_weights_gpu_resident();
 
     bool try_init_coreml_code_predictor(const std::string & model_path);

--- a/tests/test_audio_tokenizer_encoder_lifecycle.cpp
+++ b/tests/test_audio_tokenizer_encoder_lifecycle.cpp
@@ -1,0 +1,34 @@
+#include "encoder/audio_tokenizer_encoder.h"
+
+#include <cstdio>
+#include <cstdint>
+
+static ggml_tensor * fake_tensor(uintptr_t value) {
+    return reinterpret_cast<ggml_tensor *>(value);
+}
+
+int main() {
+    qwen3_tts::speaker_encoder_model model;
+
+    model.conv0_w = fake_tensor(0x1001);
+    model.conv0_b = fake_tensor(0x1002);
+    model.blocks[0].tdnn1_w = fake_tensor(0x1003);
+    model.blocks[1].res2net_w[3] = fake_tensor(0x1004);
+    model.blocks[2].se_conv2_b = fake_tensor(0x1005);
+    model.mfa_w = fake_tensor(0x1006);
+    model.asp_conv_b = fake_tensor(0x1007);
+    model.fc_b = fake_tensor(0x1008);
+    model.tensors["spk_enc.conv0.weight"] = model.conv0_w;
+
+    qwen3_tts::free_speaker_encoder_model(model);
+
+    if (model.conv0_w || model.conv0_b || model.blocks[0].tdnn1_w ||
+        model.blocks[1].res2net_w[3] || model.blocks[2].se_conv2_b ||
+        model.mfa_w || model.asp_conv_b || model.fc_b || !model.tensors.empty()) {
+        std::fprintf(stderr, "FAIL: speaker encoder model retained stale tensor pointers\n");
+        return 1;
+    }
+
+    std::printf("audio tokenizer encoder lifecycle tests passed\n");
+    return 0;
+}

--- a/tests/test_decoder.cpp
+++ b/tests/test_decoder.cpp
@@ -74,6 +74,39 @@ int main(int argc, char ** argv) {
     auto config = decoder.get_config();
     printf("  Config: sample_rate=%d, n_codebooks=%d, codebook_size=%d\n",
            config.sample_rate, config.n_codebooks, config.codebook_size);
+    if (decoder.is_ram_offloaded()) {
+        fprintf(stderr, "  FAIL: decoder should not start RAM-offloaded\n");
+        return 1;
+    }
+    if (decoder.can_offload_to_ram()) {
+        std::string offload_error;
+        if (!decoder.offload_weights_to_ram(offload_error)) {
+            fprintf(stderr, "  FAIL: decoder offload failed: %s\n", offload_error.c_str());
+            return 1;
+        }
+        if (!decoder.is_ram_offloaded()) {
+            fprintf(stderr, "  FAIL: decoder did not enter RAM-resident state\n");
+            return 1;
+        }
+        if (decoder.ram_offloaded_bytes() == 0) {
+            fprintf(stderr, "  FAIL: decoder did not retain RAM-resident weights\n");
+            return 1;
+        }
+        std::vector<float> offloaded_samples;
+        std::vector<int32_t> dummy_codes(config.n_codebooks, 0);
+        if (decoder.decode(dummy_codes.data(), 1, offloaded_samples)) {
+            fprintf(stderr, "  FAIL: decoder allowed decode while RAM-resident\n");
+            return 1;
+        }
+        if (!decoder.reload_weights_from_ram(offload_error)) {
+            fprintf(stderr, "  FAIL: decoder reload failed: %s\n", offload_error.c_str());
+            return 1;
+        }
+        if (decoder.ram_offloaded_bytes() != 0) {
+            fprintf(stderr, "  FAIL: decoder retained RAM-resident weights after reload\n");
+            return 1;
+        }
+    }
     printf("\n");
     
     printf("Test 2: Load speech codes from %s\n", codes_path);

--- a/tests/test_decoder.cpp
+++ b/tests/test_decoder.cpp
@@ -63,6 +63,18 @@ int main(int argc, char ** argv) {
     printf("=== Audio Tokenizer Decoder Test ===\n\n");
     
     qwen3_tts::AudioTokenizerDecoder decoder;
+
+    std::vector<float> unloaded_samples;
+    int32_t unloaded_code = 0;
+    if (decoder.decode(&unloaded_code, 1, unloaded_samples)) {
+        fprintf(stderr, "  FAIL: decoder allowed decode before model load\n");
+        return 1;
+    }
+    if (decoder.get_error() != "Audio decoder model is not loaded") {
+        fprintf(stderr, "  FAIL: unexpected unloaded decoder error: %s\n",
+                decoder.get_error().c_str());
+        return 1;
+    }
     
     printf("Test 1: Load model from %s\n", tokenizer_path);
     if (!decoder.load_model(tokenizer_path)) {

--- a/tests/test_gpu_idle_offload_validation.cpp
+++ b/tests/test_gpu_idle_offload_validation.cpp
@@ -125,12 +125,24 @@ int main(int argc, char ** argv) {
         return 1;
     }
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(idle_secs * 1000 + 750));
-    if (!qwen3_tts::Qwen3TTSDiagnostics::transformer_ram_offloaded(tts)) {
+    bool transformer_offloaded = false;
+    bool decoder_offloaded = false;
+    const auto deadline = std::chrono::steady_clock::now() +
+                          std::chrono::seconds(idle_secs + 5);
+    do {
+        transformer_offloaded = qwen3_tts::Qwen3TTSDiagnostics::transformer_ram_offloaded(tts);
+        decoder_offloaded = qwen3_tts::Qwen3TTSDiagnostics::decoder_ram_offloaded(tts);
+        if (transformer_offloaded && decoder_offloaded) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    } while (std::chrono::steady_clock::now() < deadline);
+
+    if (!transformer_offloaded) {
         std::fprintf(stderr, "FAIL: transformer did not RAM-offload after idle timeout; verify CUDA/Vulkan was selected\n");
         return 1;
     }
-    if (!qwen3_tts::Qwen3TTSDiagnostics::decoder_ram_offloaded(tts)) {
+    if (!decoder_offloaded) {
         std::fprintf(stderr, "FAIL: decoder did not RAM-offload after idle timeout; verify CUDA/Vulkan was selected\n");
         return 1;
     }

--- a/tests/test_gpu_idle_offload_validation.cpp
+++ b/tests/test_gpu_idle_offload_validation.cpp
@@ -1,0 +1,155 @@
+#include "pipeline/qwen3_tts.h"
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <thread>
+
+namespace {
+
+bool equals_ignore_case(const std::string & a, const char * b) {
+    if (!b) {
+        return false;
+    }
+    size_t i = 0;
+    for (; i < a.size() && b[i] != '\0'; ++i) {
+        char ca = a[i];
+        char cb = b[i];
+        if (ca >= 'A' && ca <= 'Z') ca = (char) (ca - 'A' + 'a');
+        if (cb >= 'A' && cb <= 'Z') cb = (char) (cb - 'A' + 'a');
+        if (ca != cb) {
+            return false;
+        }
+    }
+    return i == a.size() && b[i] == '\0';
+}
+
+bool env_truthy(const char * name) {
+    const char * value = std::getenv(name);
+    if (!value || value[0] == '\0') {
+        return false;
+    }
+    std::string text(value);
+    return equals_ignore_case(text, "1") ||
+           equals_ignore_case(text, "true") ||
+           equals_ignore_case(text, "yes") ||
+           equals_ignore_case(text, "on");
+}
+
+void set_env_if_unset(const char * name, const char * value) {
+    const char * current = std::getenv(name);
+    if (current && current[0] != '\0') {
+        return;
+    }
+#ifdef _WIN32
+    _putenv_s(name, value);
+#else
+    setenv(name, value, 1);
+#endif
+}
+
+int parse_positive_int_env(const char * name, int fallback) {
+    const char * value = std::getenv(name);
+    if (!value || value[0] == '\0') {
+        return fallback;
+    }
+    char * end = nullptr;
+    long parsed = std::strtol(value, &end, 10);
+    if (!end || *end != '\0' || parsed <= 0 || parsed > 3600) {
+        return -1;
+    }
+    return (int) parsed;
+}
+
+std::string model_dir_from_args(int argc, char ** argv) {
+    if (argc > 1 && argv[1] && argv[1][0] != '\0') {
+        return argv[1];
+    }
+    const char * env_model_dir = std::getenv("QWEN3_TTS_MODEL_DIR");
+    if (env_model_dir && env_model_dir[0] != '\0') {
+        return env_model_dir;
+    }
+    return "models";
+}
+
+} // namespace
+
+int main(int argc, char ** argv) {
+    if (!env_truthy("QWEN3_TTS_RUN_GPU_OFFLOAD_VALIDATION")) {
+        std::printf("SKIP: set QWEN3_TTS_RUN_GPU_OFFLOAD_VALIDATION=1 to run the CUDA/Vulkan idle offload validation\n");
+        return 0;
+    }
+
+    set_env_if_unset("QWEN3_TTS_GPU_OFFLOAD_IDLE_SECS", "1");
+    set_env_if_unset("QWEN3_TTS_LOW_MEM", "0");
+
+    if (env_truthy("QWEN3_TTS_LOW_MEM")) {
+        std::fprintf(stderr, "FAIL: QWEN3_TTS_LOW_MEM disables idle GPU RAM offload\n");
+        return 1;
+    }
+
+    const char * backend = std::getenv("QWEN3_TTS_BACKEND");
+    if (backend && equals_ignore_case(backend, "cpu")) {
+        std::fprintf(stderr, "FAIL: QWEN3_TTS_BACKEND=cpu cannot validate CUDA/Vulkan idle offload\n");
+        return 1;
+    }
+
+    const int idle_secs = parse_positive_int_env("QWEN3_TTS_GPU_OFFLOAD_IDLE_SECS", 1);
+    if (idle_secs <= 0) {
+        std::fprintf(stderr, "FAIL: QWEN3_TTS_GPU_OFFLOAD_IDLE_SECS must be a positive integer for validation\n");
+        return 1;
+    }
+
+    qwen3_tts::Qwen3TTS tts;
+    const std::string model_dir = model_dir_from_args(argc, argv);
+    if (!tts.load_models(model_dir)) {
+        std::fprintf(stderr, "FAIL: models unavailable in %s: %s\n",
+                     model_dir.c_str(), tts.get_error().c_str());
+        return 1;
+    }
+
+    qwen3_tts::tts_params params;
+    params.max_audio_tokens = 8;
+    params.temperature = 0.0f;
+    params.seed = 1;
+    params.print_timing = false;
+
+    auto first = tts.synthesize("gpu idle offload validation", params);
+    if (!first.success) {
+        std::fprintf(stderr, "FAIL: initial synthesis failed: %s\n", first.error_msg.c_str());
+        return 1;
+    }
+    if (first.audio.empty()) {
+        std::fprintf(stderr, "FAIL: initial synthesis produced empty audio\n");
+        return 1;
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(idle_secs * 1000 + 750));
+    if (!qwen3_tts::Qwen3TTSDiagnostics::transformer_ram_offloaded(tts)) {
+        std::fprintf(stderr, "FAIL: transformer did not RAM-offload after idle timeout; verify CUDA/Vulkan was selected\n");
+        return 1;
+    }
+    if (!qwen3_tts::Qwen3TTSDiagnostics::decoder_ram_offloaded(tts)) {
+        std::fprintf(stderr, "FAIL: decoder did not RAM-offload after idle timeout; verify CUDA/Vulkan was selected\n");
+        return 1;
+    }
+
+    auto second = tts.synthesize("gpu idle offload reload validation", params);
+    if (!second.success) {
+        std::fprintf(stderr, "FAIL: synthesis after RAM offload failed: %s\n", second.error_msg.c_str());
+        return 1;
+    }
+    if (second.audio.empty()) {
+        std::fprintf(stderr, "FAIL: synthesis after RAM offload produced empty audio\n");
+        return 1;
+    }
+    if (qwen3_tts::Qwen3TTSDiagnostics::transformer_ram_offloaded(tts) ||
+        qwen3_tts::Qwen3TTSDiagnostics::decoder_ram_offloaded(tts)) {
+        std::fprintf(stderr, "FAIL: synthesis after idle offload did not reload all RAM-resident weights\n");
+        return 1;
+    }
+
+    std::printf("gpu idle offload validation passed\n");
+    return 0;
+}

--- a/tests/test_gpu_offload_policy.cpp
+++ b/tests/test_gpu_offload_policy.cpp
@@ -1,0 +1,37 @@
+#include "common/gpu_offload_policy.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+static int fail(const char * msg) {
+    std::fprintf(stderr, "FAIL: %s\n", msg);
+    return 1;
+}
+
+static int expect_policy(const char * env_value, bool low_mem,
+                         bool expected_enabled, int expected_secs,
+                         const char * expected_reason_substr) {
+    qwen3_tts::gpu_offload_policy p =
+        qwen3_tts::parse_gpu_offload_policy(env_value, low_mem);
+    if (p.enabled != expected_enabled) return fail("enabled mismatch");
+    if (p.idle_secs != expected_secs) return fail("idle_secs mismatch");
+    if (expected_reason_substr &&
+        p.reason.find(expected_reason_substr) == std::string::npos) {
+        return fail("reason mismatch");
+    }
+    return 0;
+}
+
+int main() {
+    if (expect_policy(nullptr, false, false, 0, "unset") != 0) return 1;
+    if (expect_policy("", false, false, 0, "unset") != 0) return 1;
+    if (expect_policy("0", false, false, 0, "disabled") != 0) return 1;
+    if (expect_policy("15", false, true, 15, "enabled") != 0) return 1;
+    if (expect_policy("-2", false, false, 0, "invalid") != 0) return 1;
+    if (expect_policy("abc", false, false, 0, "invalid") != 0) return 1;
+    if (expect_policy("15", true, false, 0, "QWEN3_TTS_LOW_MEM") != 0) return 1;
+    std::printf("gpu_offload_policy tests passed\n");
+    return 0;
+}

--- a/tests/test_gpu_offload_policy.cpp
+++ b/tests/test_gpu_offload_policy.cpp
@@ -31,6 +31,11 @@ int main() {
     if (expect_policy("15", false, true, 15, "enabled") != 0) return 1;
     if (expect_policy("-2", false, false, 0, "invalid") != 0) return 1;
     if (expect_policy("abc", false, false, 0, "invalid") != 0) return 1;
+    if (expect_policy(" 15", false, false, 0, "invalid") != 0) return 1;
+    if (expect_policy("+15", false, false, 0, "invalid") != 0) return 1;
+    if (expect_policy("15s", false, false, 0, "invalid") != 0) return 1;
+    if (expect_policy("2147483648", false, false, 0, "invalid") != 0) return 1;
+    if (expect_policy("999999999999999999999999999999", false, false, 0, "invalid") != 0) return 1;
     if (expect_policy("15", true, false, 0, "QWEN3_TTS_LOW_MEM") != 0) return 1;
     std::printf("gpu_offload_policy tests passed\n");
     return 0;

--- a/tests/test_pipeline_offload_lifecycle.cpp
+++ b/tests/test_pipeline_offload_lifecycle.cpp
@@ -1,0 +1,101 @@
+#include "pipeline/qwen3_tts.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <thread>
+#include <chrono>
+#include <vector>
+
+static void set_test_env(const char * name, const char * value) {
+#ifdef _WIN32
+    _putenv_s(name, value);
+#else
+    setenv(name, value, 1);
+#endif
+}
+
+int main() {
+    set_test_env("QWEN3_TTS_GPU_OFFLOAD_IDLE_SECS", "1");
+    set_test_env("QWEN3_TTS_BACKEND", "cpu");
+    set_test_env("QWEN3_TTS_LOW_MEM", "0");
+
+    qwen3_tts::Qwen3TTS tts;
+    if (!tts.load_models("models")) {
+        std::fprintf(stderr, "SKIP: models unavailable: %s\n", tts.get_error().c_str());
+        return 0;
+    }
+
+    const auto names = tts.get_speaker_names();
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(1200));
+    if (qwen3_tts::Qwen3TTSDiagnostics::transformer_ram_offloaded(tts)) {
+        std::fprintf(stderr, "FAIL: CPU backend production path offloaded transformer\n");
+        return 1;
+    }
+
+    qwen3_tts::tts_params params;
+    params.max_audio_tokens = 1;
+    auto result = tts.synthesize("test", params);
+    if (!result.success) {
+        std::fprintf(stderr, "FAIL: synthesize failed: %s\n", result.error_msg.c_str());
+        return 1;
+    }
+
+    if (!names.empty()) {
+        std::string err;
+        if (!qwen3_tts::Qwen3TTSDiagnostics::force_transformer_offload(tts, err)) {
+            std::fprintf(stderr, "FAIL: forced transformer offload failed: %s\n", err.c_str());
+            return 1;
+        }
+        if (!qwen3_tts::Qwen3TTSDiagnostics::transformer_ram_offloaded(tts)) {
+            std::fprintf(stderr, "FAIL: transformer did not report RAM-offloaded\n");
+            return 1;
+        }
+
+        std::vector<float> embedding;
+        if (!tts.get_speaker_embedding(names[0], embedding)) {
+            std::fprintf(stderr, "FAIL: get_speaker_embedding failed after forced offload: %s\n",
+                         tts.get_error().c_str());
+            return 1;
+        }
+        if (embedding.empty()) {
+            std::fprintf(stderr, "FAIL: get_speaker_embedding returned an empty embedding\n");
+            return 1;
+        }
+        if (qwen3_tts::Qwen3TTSDiagnostics::transformer_ram_offloaded(tts)) {
+            std::fprintf(stderr, "FAIL: get_speaker_embedding did not reload transformer\n");
+            return 1;
+        }
+    }
+
+    std::string err;
+    if (!qwen3_tts::Qwen3TTSDiagnostics::force_idle_offload_once(tts, err)) {
+        std::fprintf(stderr, "FAIL: forced idle offload failed: %s\n", err.c_str());
+        return 1;
+    }
+    if (!qwen3_tts::Qwen3TTSDiagnostics::transformer_ram_offloaded(tts)) {
+        std::fprintf(stderr, "FAIL: forced idle offload did not offload transformer\n");
+        return 1;
+    }
+
+    result = tts.synthesize("test", params);
+    if (!result.success) {
+        std::fprintf(stderr, "FAIL: synthesize failed after forced idle offload: %s\n",
+                     result.error_msg.c_str());
+        return 1;
+    }
+    if (qwen3_tts::Qwen3TTSDiagnostics::transformer_ram_offloaded(tts)) {
+        std::fprintf(stderr, "FAIL: guarded synthesize did not reload transformer after idle offload\n");
+        return 1;
+    }
+
+    if (!tts.load_models("models")) {
+        std::fprintf(stderr, "FAIL: reload after forced idle offload failed: %s\n",
+                     tts.get_error().c_str());
+        return 1;
+    }
+
+    std::printf("pipeline offload lifecycle test passed\n");
+    return 0;
+}

--- a/tests/test_pipeline_offload_lifecycle.cpp
+++ b/tests/test_pipeline_offload_lifecycle.cpp
@@ -35,7 +35,8 @@ int main() {
     }
 
     qwen3_tts::tts_params params;
-    params.max_audio_tokens = 1;
+    // Keep this short, but above the vocoder's reflect-padding minimum.
+    params.max_audio_tokens = 8;
     auto result = tts.synthesize("test", params);
     if (!result.success) {
         std::fprintf(stderr, "FAIL: synthesize failed: %s\n", result.error_msg.c_str());

--- a/tests/test_transformer.cpp
+++ b/tests/test_transformer.cpp
@@ -179,6 +179,25 @@ int main(int argc, char ** argv) {
            config.hidden_size, config.n_layers, config.n_attention_heads, config.n_key_value_heads);
     printf("  Codec: vocab_size=%d, n_codebooks=%d\n", config.codec_vocab_size, config.n_codebooks);
     printf("  Code predictor: layers=%d, vocab_size=%d\n", config.code_pred_layers, config.code_pred_vocab_size);
+    if (transformer.is_ram_offloaded()) {
+        fprintf(stderr, "  FAIL: transformer should not start RAM-offloaded\n");
+        return 1;
+    }
+    if (transformer.can_offload_to_ram()) {
+        std::string offload_error;
+        if (!transformer.offload_weights_to_ram(offload_error)) {
+            fprintf(stderr, "  FAIL: transformer offload failed: %s\n", offload_error.c_str());
+            return 1;
+        }
+        if (!transformer.is_ram_offloaded()) {
+            fprintf(stderr, "  FAIL: transformer did not enter RAM-resident state\n");
+            return 1;
+        }
+        if (!transformer.reload_weights_from_ram(offload_error)) {
+            fprintf(stderr, "  FAIL: transformer reload failed: %s\n", offload_error.c_str());
+            return 1;
+        }
+    }
     test_pass("Model loaded successfully");
 
     // -----------------------------------------------------------------------

--- a/tests/test_transformer.cpp
+++ b/tests/test_transformer.cpp
@@ -193,8 +193,20 @@ int main(int argc, char ** argv) {
             fprintf(stderr, "  FAIL: transformer did not enter RAM-resident state\n");
             return 1;
         }
+        if (transformer.ram_offloaded_bytes() == 0) {
+            fprintf(stderr, "  FAIL: transformer did not retain RAM-resident weights\n");
+            return 1;
+        }
+        if (transformer.init_kv_cache(16)) {
+            fprintf(stderr, "  FAIL: transformer allowed KV cache init while RAM-resident\n");
+            return 1;
+        }
         if (!transformer.reload_weights_from_ram(offload_error)) {
             fprintf(stderr, "  FAIL: transformer reload failed: %s\n", offload_error.c_str());
+            return 1;
+        }
+        if (transformer.ram_offloaded_bytes() != 0) {
+            fprintf(stderr, "  FAIL: transformer retained RAM-resident weights after reload\n");
             return 1;
         }
     }

--- a/tests/test_weight_residency.cpp
+++ b/tests/test_weight_residency.cpp
@@ -4,10 +4,8 @@
 #include "ggml-backend.h"
 
 #include <cstdio>
-#include <cstring>
 #include <map>
 #include <string>
-#include <vector>
 
 static int fail(const char * msg) {
     std::fprintf(stderr, "FAIL: %s\n", msg);
@@ -31,6 +29,38 @@ static int run_download_rejects_null_tensor() {
     }
     if (!store.tensors.empty()) return fail("null tensor failure left tensor copies");
     if (store.total_bytes != 0) return fail("null tensor failure left total bytes");
+    return 0;
+}
+
+static int run_download_rejects_unallocated_tensor() {
+    ggml_init_params params = {
+        /*.mem_size   =*/ ggml_tensor_overhead() * 2,
+        /*.mem_buffer =*/ nullptr,
+        /*.no_alloc   =*/ true,
+    };
+    ggml_context * ctx = ggml_init(params);
+    if (!ctx) return fail("ggml_init failed");
+
+    ggml_tensor * t = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, 4);
+    ggml_set_name(t, "unallocated.weight");
+    std::map<std::string, ggml_tensor *> tensors;
+    tensors["unallocated.weight"] = t;
+
+    qwen3_tts::host_tensor_store store;
+    qwen3_tts::host_tensor_copy existing;
+    existing.name = "old.weight";
+    existing.bytes.push_back(42);
+    store.tensors.push_back(existing);
+    store.total_bytes = 1;
+
+    std::string error;
+    const bool ok = qwen3_tts::download_tensors_to_host(tensors, store, error);
+    ggml_free(ctx);
+
+    if (ok) return fail("download accepted unallocated tensor");
+    if (error.find("unallocated") == std::string::npos) return fail("unallocated tensor error mismatch");
+    if (!store.tensors.empty()) return fail("unallocated tensor failure left tensor copies");
+    if (store.total_bytes != 0) return fail("unallocated tensor failure left total bytes");
     return 0;
 }
 
@@ -195,6 +225,7 @@ static int run_backend_roundtrip(enum ggml_backend_dev_type type, bool optional)
 
 int main() {
     if (run_download_rejects_null_tensor() != 0) return 1;
+    if (run_download_rejects_unallocated_tensor() != 0) return 1;
     if (run_upload_rejects_missing_destination() != 0) return 1;
     if (run_upload_rejects_non_null_buffer() != 0) return 1;
     if (run_backend_roundtrip(GGML_BACKEND_DEVICE_TYPE_CPU, false) != 0) return 1;

--- a/tests/test_weight_residency.cpp
+++ b/tests/test_weight_residency.cpp
@@ -540,6 +540,48 @@ static int run_upload_rejects_aliased_destination_tensor() {
     return 0;
 }
 
+static int run_upload_rejects_allocating_context() {
+    ggml_backend_t backend = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, nullptr);
+    if (!backend) return fail("backend init failed");
+
+    ggml_init_params params = {
+        /*.mem_size   =*/ ggml_tensor_overhead() * 2 + 4 * sizeof(float),
+        /*.mem_buffer =*/ nullptr,
+        /*.no_alloc   =*/ false,
+    };
+    ggml_context * ctx = ggml_init(params);
+    if (!ctx) {
+        ggml_backend_free(backend);
+        return fail("ggml_init failed");
+    }
+
+    ggml_tensor * t = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, 4);
+    ggml_set_name(t, "test.weight");
+    std::map<std::string, ggml_tensor *> tensors;
+    tensors["test.weight"] = t;
+
+    qwen3_tts::host_tensor_store store;
+    qwen3_tts::host_tensor_copy copy;
+    copy.name = "test.weight";
+    copy.bytes.resize(4 * sizeof(float));
+    store.total_bytes = copy.bytes.size();
+    store.tensors.push_back(copy);
+
+    ggml_backend_buffer_t buffer = nullptr;
+    std::string error;
+    const bool ok = qwen3_tts::upload_tensors_from_host(ctx, tensors, backend, store, buffer, error);
+    const bool buffer_changed = buffer != nullptr;
+
+    if (buffer) ggml_backend_buffer_free(buffer);
+    ggml_free(ctx);
+    ggml_backend_free(backend);
+
+    if (ok) return fail("upload accepted allocating context");
+    if (error.find("no_alloc") == std::string::npos) return fail("allocating context error mismatch");
+    if (buffer_changed) return fail("allocating context failure changed buffer");
+    return 0;
+}
+
 static int run_backend_roundtrip(enum ggml_backend_dev_type type, bool optional) {
     ggml_backend_t backend = ggml_backend_init_by_type(type, nullptr);
     if (!backend) {
@@ -605,6 +647,7 @@ int main() {
     if (run_upload_rejects_duplicate_store_name() != 0) return 1;
     if (run_upload_rejects_subset_destination_map() != 0) return 1;
     if (run_upload_rejects_aliased_destination_tensor() != 0) return 1;
+    if (run_upload_rejects_allocating_context() != 0) return 1;
     if (run_backend_roundtrip(GGML_BACKEND_DEVICE_TYPE_CPU, false) != 0) return 1;
     if (run_backend_roundtrip(GGML_BACKEND_DEVICE_TYPE_GPU, true) != 0) return 1;
     std::printf("weight_residency tests passed\n");

--- a/tests/test_weight_residency.cpp
+++ b/tests/test_weight_residency.cpp
@@ -313,6 +313,53 @@ static int run_upload_rejects_duplicate_store_name() {
     return 0;
 }
 
+static int run_upload_rejects_subset_destination_map() {
+    ggml_backend_t backend = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, nullptr);
+    if (!backend) return fail("backend init failed");
+
+    ggml_init_params params = {
+        /*.mem_size   =*/ ggml_tensor_overhead() * 3,
+        /*.mem_buffer =*/ nullptr,
+        /*.no_alloc   =*/ true,
+    };
+    ggml_context * ctx = ggml_init(params);
+    if (!ctx) {
+        ggml_backend_free(backend);
+        return fail("ggml_init failed");
+    }
+
+    ggml_tensor * t = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, 4);
+    ggml_set_name(t, "test.weight");
+    ggml_tensor * extra = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, 4);
+    ggml_set_name(extra, "extra.weight");
+
+    std::map<std::string, ggml_tensor *> tensors;
+    tensors["test.weight"] = t;
+
+    qwen3_tts::host_tensor_store store;
+    qwen3_tts::host_tensor_copy copy;
+    copy.name = "test.weight";
+    copy.bytes.resize(4 * sizeof(float));
+    store.total_bytes = copy.bytes.size();
+    store.tensors.push_back(copy);
+
+    ggml_backend_buffer_t buffer = nullptr;
+    std::string error;
+    const bool ok = qwen3_tts::upload_tensors_from_host(ctx, tensors, backend, store, buffer, error);
+    const bool buffer_changed = buffer != nullptr;
+
+    if (buffer) ggml_backend_buffer_free(buffer);
+    ggml_free(ctx);
+    ggml_backend_free(backend);
+
+    if (ok) return fail("upload accepted subset destination map");
+    if (error.find("context") == std::string::npos && error.find("destination") == std::string::npos) {
+        return fail("subset destination map error mismatch");
+    }
+    if (buffer_changed) return fail("subset destination map failure changed buffer");
+    return 0;
+}
+
 static int run_backend_roundtrip(enum ggml_backend_dev_type type, bool optional) {
     ggml_backend_t backend = ggml_backend_init_by_type(type, nullptr);
     if (!backend) {
@@ -373,6 +420,7 @@ int main() {
     if (run_upload_rejects_wrong_context_tensor() != 0) return 1;
     if (run_upload_rejects_incomplete_store() != 0) return 1;
     if (run_upload_rejects_duplicate_store_name() != 0) return 1;
+    if (run_upload_rejects_subset_destination_map() != 0) return 1;
     if (run_backend_roundtrip(GGML_BACKEND_DEVICE_TYPE_CPU, false) != 0) return 1;
     if (run_backend_roundtrip(GGML_BACKEND_DEVICE_TYPE_GPU, true) != 0) return 1;
     std::printf("weight_residency tests passed\n");

--- a/tests/test_weight_residency.cpp
+++ b/tests/test_weight_residency.cpp
@@ -64,6 +64,51 @@ static int run_download_rejects_unallocated_tensor() {
     return 0;
 }
 
+static int run_download_rejects_name_mismatch() {
+    ggml_backend_t backend = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, nullptr);
+    if (!backend) return fail("backend init failed");
+
+    ggml_init_params params = {
+        /*.mem_size   =*/ ggml_tensor_overhead() * 2,
+        /*.mem_buffer =*/ nullptr,
+        /*.no_alloc   =*/ true,
+    };
+    ggml_context * ctx = ggml_init(params);
+    if (!ctx) {
+        ggml_backend_free(backend);
+        return fail("ggml_init failed");
+    }
+
+    ggml_tensor * t = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, 4);
+    ggml_set_name(t, "real.weight");
+    std::map<std::string, ggml_tensor *> tensors;
+    tensors["wrong.weight"] = t;
+
+    ggml_backend_buffer_t buffer = ggml_backend_alloc_ctx_tensors(ctx, backend);
+    if (!buffer) {
+        ggml_free(ctx);
+        ggml_backend_free(backend);
+        return fail("alloc buffer failed");
+    }
+
+    float input[4] = {1.0f, 2.0f, 3.0f, 4.0f};
+    ggml_backend_tensor_set(t, input, 0, sizeof(input));
+
+    qwen3_tts::host_tensor_store store;
+    std::string error;
+    const bool ok = qwen3_tts::download_tensors_to_host(tensors, store, error);
+
+    ggml_backend_buffer_free(buffer);
+    ggml_free(ctx);
+    ggml_backend_free(backend);
+
+    if (ok) return fail("download accepted name mismatch");
+    if (error.find("name") == std::string::npos) return fail("download name mismatch error mismatch");
+    if (!store.tensors.empty()) return fail("download name mismatch left tensor copies");
+    if (store.total_bytes != 0) return fail("download name mismatch left total bytes");
+    return 0;
+}
+
 static int run_upload_rejects_missing_destination() {
     ggml_backend_t backend = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, nullptr);
     if (!backend) return fail("backend init failed");
@@ -114,6 +159,48 @@ static int run_upload_rejects_missing_destination() {
     ggml_free(ctx);
     ggml_backend_free(backend);
     return result;
+}
+
+static int run_upload_rejects_name_mismatch() {
+    ggml_backend_t backend = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, nullptr);
+    if (!backend) return fail("backend init failed");
+
+    ggml_init_params params = {
+        /*.mem_size   =*/ ggml_tensor_overhead() * 2,
+        /*.mem_buffer =*/ nullptr,
+        /*.no_alloc   =*/ true,
+    };
+    ggml_context * ctx = ggml_init(params);
+    if (!ctx) {
+        ggml_backend_free(backend);
+        return fail("ggml_init failed");
+    }
+
+    ggml_tensor * t = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, 4);
+    ggml_set_name(t, "real.weight");
+    std::map<std::string, ggml_tensor *> tensors;
+    tensors["wrong.weight"] = t;
+
+    qwen3_tts::host_tensor_store store;
+    qwen3_tts::host_tensor_copy copy;
+    copy.name = "wrong.weight";
+    copy.bytes.resize(4 * sizeof(float));
+    store.total_bytes = copy.bytes.size();
+    store.tensors.push_back(copy);
+
+    ggml_backend_buffer_t buffer = nullptr;
+    std::string error;
+    const bool ok = qwen3_tts::upload_tensors_from_host(ctx, tensors, backend, store, buffer, error);
+    const bool buffer_changed = buffer != nullptr;
+
+    if (buffer) ggml_backend_buffer_free(buffer);
+    ggml_free(ctx);
+    ggml_backend_free(backend);
+
+    if (ok) return fail("upload accepted name mismatch");
+    if (error.find("name") == std::string::npos) return fail("upload name mismatch error mismatch");
+    if (buffer_changed) return fail("upload name mismatch failure changed buffer");
+    return 0;
 }
 
 static int run_upload_rejects_non_null_buffer() {
@@ -463,7 +550,9 @@ static int run_backend_roundtrip(enum ggml_backend_dev_type type, bool optional)
 int main() {
     if (run_download_rejects_null_tensor() != 0) return 1;
     if (run_download_rejects_unallocated_tensor() != 0) return 1;
+    if (run_download_rejects_name_mismatch() != 0) return 1;
     if (run_upload_rejects_missing_destination() != 0) return 1;
+    if (run_upload_rejects_name_mismatch() != 0) return 1;
     if (run_upload_rejects_non_null_buffer() != 0) return 1;
     if (run_upload_rejects_wrong_context_tensor() != 0) return 1;
     if (run_upload_rejects_incomplete_store() != 0) return 1;

--- a/tests/test_weight_residency.cpp
+++ b/tests/test_weight_residency.cpp
@@ -1,0 +1,70 @@
+#include "common/weight_residency.h"
+
+#include "ggml.h"
+#include "ggml-backend.h"
+
+#include <cstdio>
+#include <cstring>
+#include <map>
+#include <string>
+#include <vector>
+
+static int fail(const char * msg) {
+    std::fprintf(stderr, "FAIL: %s\n", msg);
+    return 1;
+}
+
+static int run_backend_roundtrip(enum ggml_backend_dev_type type) {
+    ggml_backend_t backend = ggml_backend_init_by_type(type, nullptr);
+    if (!backend) return 0; // optional backend unavailable
+
+    ggml_init_params params = {
+        /*.mem_size   =*/ ggml_tensor_overhead() * 2,
+        /*.mem_buffer =*/ nullptr,
+        /*.no_alloc   =*/ true,
+    };
+    ggml_context * ctx = ggml_init(params);
+    if (!ctx) return fail("ggml_init failed");
+
+    ggml_tensor * t = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, 4);
+    ggml_set_name(t, "test.weight");
+    std::map<std::string, ggml_tensor *> tensors;
+    tensors["test.weight"] = t;
+
+    ggml_backend_buffer_t buffer = ggml_backend_alloc_ctx_tensors(ctx, backend);
+    if (!buffer) return fail("alloc buffer failed");
+
+    float input[4] = {1.0f, 2.0f, 3.0f, 4.0f};
+    ggml_backend_tensor_set(t, input, 0, sizeof(input));
+
+    qwen3_tts::host_tensor_store store;
+    std::string error;
+    if (!qwen3_tts::download_tensors_to_host(tensors, store, error)) {
+        return fail(error.c_str());
+    }
+
+    ggml_backend_buffer_free(buffer);
+    buffer = nullptr;
+
+    if (!qwen3_tts::upload_tensors_from_host(ctx, tensors, backend, store, buffer, error)) {
+        return fail(error.c_str());
+    }
+
+    float output[4] = {};
+    ggml_backend_tensor_get(t, output, 0, sizeof(output));
+    for (int i = 0; i < 4; ++i) {
+        if (output[i] != input[i]) return fail("roundtrip mismatch");
+    }
+
+    ggml_backend_buffer_free(buffer);
+    ggml_free(ctx);
+    ggml_backend_free(backend);
+    return 0;
+}
+
+int main() {
+    if (run_backend_roundtrip(GGML_BACKEND_DEVICE_TYPE_CPU) != 0) return 1;
+    (void) run_backend_roundtrip(GGML_BACKEND_DEVICE_TYPE_GPU);
+    std::printf("weight_residency tests passed\n");
+    return 0;
+}

--- a/tests/test_weight_residency.cpp
+++ b/tests/test_weight_residency.cpp
@@ -279,17 +279,20 @@ static int run_upload_rejects_wrong_context_tensor() {
     ggml_tensor * ctx_a_tensor = ggml_new_tensor_1d(ctx_a, GGML_TYPE_F32, 4);
     ggml_set_name(ctx_a_tensor, "ctx_a.weight");
     ggml_tensor * ctx_b_tensor = ggml_new_tensor_1d(ctx_b, GGML_TYPE_F32, 4);
-    ggml_set_name(ctx_b_tensor, "test.weight");
+    ggml_set_name(ctx_b_tensor, "ctx_b.weight");
 
     std::map<std::string, ggml_tensor *> tensors;
-    tensors["test.weight"] = ctx_b_tensor;
+    tensors["ctx_a.weight"] = ctx_a_tensor;
+    tensors["ctx_b.weight"] = ctx_b_tensor;
 
     qwen3_tts::host_tensor_store store;
     qwen3_tts::host_tensor_copy copy;
-    copy.name = "test.weight";
     copy.bytes.resize(4 * sizeof(float));
-    store.total_bytes = copy.bytes.size();
+    copy.name = "ctx_a.weight";
     store.tensors.push_back(copy);
+    copy.name = "ctx_b.weight";
+    store.tensors.push_back(copy);
+    store.total_bytes = copy.bytes.size() * 2;
 
     ggml_backend_buffer_t buffer = nullptr;
     std::string error;
@@ -306,6 +309,48 @@ static int run_upload_rejects_wrong_context_tensor() {
         return fail("wrong-context tensor error mismatch");
     }
     if (buffer_changed) return fail("wrong-context failure changed buffer");
+    return 0;
+}
+
+static int run_upload_rejects_total_bytes_mismatch() {
+    ggml_backend_t backend = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, nullptr);
+    if (!backend) return fail("backend init failed");
+
+    ggml_init_params params = {
+        /*.mem_size   =*/ ggml_tensor_overhead() * 2,
+        /*.mem_buffer =*/ nullptr,
+        /*.no_alloc   =*/ true,
+    };
+    ggml_context * ctx = ggml_init(params);
+    if (!ctx) {
+        ggml_backend_free(backend);
+        return fail("ggml_init failed");
+    }
+
+    ggml_tensor * t = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, 4);
+    ggml_set_name(t, "test.weight");
+    std::map<std::string, ggml_tensor *> tensors;
+    tensors["test.weight"] = t;
+
+    qwen3_tts::host_tensor_store store;
+    qwen3_tts::host_tensor_copy copy;
+    copy.name = "test.weight";
+    copy.bytes.resize(4 * sizeof(float));
+    store.tensors.push_back(copy);
+    store.total_bytes = copy.bytes.size() + 1;
+
+    ggml_backend_buffer_t buffer = nullptr;
+    std::string error;
+    const bool ok = qwen3_tts::upload_tensors_from_host(ctx, tensors, backend, store, buffer, error);
+    const bool buffer_changed = buffer != nullptr;
+
+    if (buffer) ggml_backend_buffer_free(buffer);
+    ggml_free(ctx);
+    ggml_backend_free(backend);
+
+    if (ok) return fail("upload accepted total bytes mismatch");
+    if (error.find("total") == std::string::npos) return fail("total bytes mismatch error mismatch");
+    if (buffer_changed) return fail("total bytes mismatch failure changed buffer");
     return 0;
 }
 
@@ -555,6 +600,7 @@ int main() {
     if (run_upload_rejects_name_mismatch() != 0) return 1;
     if (run_upload_rejects_non_null_buffer() != 0) return 1;
     if (run_upload_rejects_wrong_context_tensor() != 0) return 1;
+    if (run_upload_rejects_total_bytes_mismatch() != 0) return 1;
     if (run_upload_rejects_incomplete_store() != 0) return 1;
     if (run_upload_rejects_duplicate_store_name() != 0) return 1;
     if (run_upload_rejects_subset_destination_map() != 0) return 1;

--- a/tests/test_weight_residency.cpp
+++ b/tests/test_weight_residency.cpp
@@ -14,6 +14,133 @@ static int fail(const char * msg) {
     return 1;
 }
 
+static int run_download_rejects_null_tensor() {
+    qwen3_tts::host_tensor_store store;
+    qwen3_tts::host_tensor_copy existing;
+    existing.name = "old.weight";
+    existing.bytes.push_back(42);
+    store.tensors.push_back(existing);
+    store.total_bytes = 1;
+
+    std::map<std::string, ggml_tensor *> tensors;
+    tensors["null.weight"] = nullptr;
+
+    std::string error;
+    if (qwen3_tts::download_tensors_to_host(tensors, store, error)) {
+        return fail("download accepted null tensor");
+    }
+    if (!store.tensors.empty()) return fail("null tensor failure left tensor copies");
+    if (store.total_bytes != 0) return fail("null tensor failure left total bytes");
+    return 0;
+}
+
+static int run_upload_rejects_missing_destination() {
+    ggml_backend_t backend = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, nullptr);
+    if (!backend) return fail("backend init failed");
+
+    ggml_init_params params = {
+        /*.mem_size   =*/ ggml_tensor_overhead() * 2,
+        /*.mem_buffer =*/ nullptr,
+        /*.no_alloc   =*/ true,
+    };
+    ggml_context * ctx = ggml_init(params);
+    if (!ctx) {
+        ggml_backend_free(backend);
+        return fail("ggml_init failed");
+    }
+
+    ggml_tensor * t = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, 4);
+    ggml_set_name(t, "test.weight");
+    std::map<std::string, ggml_tensor *> tensors;
+    tensors["test.weight"] = t;
+
+    ggml_backend_buffer_t buffer = ggml_backend_alloc_ctx_tensors(ctx, backend);
+    if (!buffer) {
+        ggml_free(ctx);
+        ggml_backend_free(backend);
+        return fail("alloc buffer failed");
+    }
+
+    float input[4] = {1.0f, 2.0f, 3.0f, 4.0f};
+    ggml_backend_tensor_set(t, input, 0, sizeof(input));
+
+    qwen3_tts::host_tensor_store store;
+    std::string error;
+    int result = 0;
+    if (!qwen3_tts::download_tensors_to_host(tensors, store, error)) {
+        result = fail(error.c_str());
+    } else {
+        std::map<std::string, ggml_tensor *> missing;
+        ggml_backend_buffer_t upload_buffer = nullptr;
+        if (qwen3_tts::upload_tensors_from_host(ctx, missing, backend, store, upload_buffer, error)) {
+            result = fail("upload accepted missing destination tensor");
+        } else if (upload_buffer != nullptr) {
+            result = fail("missing destination failure changed buffer");
+        }
+        if (upload_buffer) ggml_backend_buffer_free(upload_buffer);
+    }
+
+    ggml_backend_buffer_free(buffer);
+    ggml_free(ctx);
+    ggml_backend_free(backend);
+    return result;
+}
+
+static int run_upload_rejects_non_null_buffer() {
+    ggml_backend_t backend = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, nullptr);
+    if (!backend) return fail("backend init failed");
+
+    ggml_init_params params = {
+        /*.mem_size   =*/ ggml_tensor_overhead() * 2,
+        /*.mem_buffer =*/ nullptr,
+        /*.no_alloc   =*/ true,
+    };
+    ggml_context * ctx = ggml_init(params);
+    if (!ctx) {
+        ggml_backend_free(backend);
+        return fail("ggml_init failed");
+    }
+
+    ggml_tensor * t = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, 4);
+    ggml_set_name(t, "test.weight");
+    std::map<std::string, ggml_tensor *> tensors;
+    tensors["test.weight"] = t;
+
+    ggml_backend_buffer_t buffer = ggml_backend_alloc_ctx_tensors(ctx, backend);
+    if (!buffer) {
+        ggml_free(ctx);
+        ggml_backend_free(backend);
+        return fail("alloc buffer failed");
+    }
+
+    float input[4] = {1.0f, 2.0f, 3.0f, 4.0f};
+    ggml_backend_tensor_set(t, input, 0, sizeof(input));
+
+    qwen3_tts::host_tensor_store store;
+    std::string error;
+    int result = 0;
+    if (!qwen3_tts::download_tensors_to_host(tensors, store, error)) {
+        result = fail(error.c_str());
+    } else {
+        ggml_backend_buffer_t original_buffer = buffer;
+        if (qwen3_tts::upload_tensors_from_host(ctx, tensors, backend, store, buffer, error)) {
+            result = fail("upload accepted non-null buffer");
+        } else if (buffer != original_buffer) {
+            result = fail("non-null buffer failure changed buffer");
+        }
+
+        if (buffer != original_buffer && buffer) {
+            ggml_backend_buffer_free(buffer);
+            buffer = original_buffer;
+        }
+    }
+
+    ggml_backend_buffer_free(buffer);
+    ggml_free(ctx);
+    ggml_backend_free(backend);
+    return result;
+}
+
 static int run_backend_roundtrip(enum ggml_backend_dev_type type, bool optional) {
     ggml_backend_t backend = ggml_backend_init_by_type(type, nullptr);
     if (!backend) {
@@ -44,6 +171,8 @@ static int run_backend_roundtrip(enum ggml_backend_dev_type type, bool optional)
     if (!qwen3_tts::download_tensors_to_host(tensors, store, error)) {
         return fail(error.c_str());
     }
+    if (store.total_bytes != sizeof(input)) return fail("host store total bytes mismatch");
+    if (store.tensors.size() != 1) return fail("host store tensor count mismatch");
 
     ggml_backend_buffer_free(buffer);
     buffer = nullptr;
@@ -65,6 +194,9 @@ static int run_backend_roundtrip(enum ggml_backend_dev_type type, bool optional)
 }
 
 int main() {
+    if (run_download_rejects_null_tensor() != 0) return 1;
+    if (run_upload_rejects_missing_destination() != 0) return 1;
+    if (run_upload_rejects_non_null_buffer() != 0) return 1;
     if (run_backend_roundtrip(GGML_BACKEND_DEVICE_TYPE_CPU, false) != 0) return 1;
     if (run_backend_roundtrip(GGML_BACKEND_DEVICE_TYPE_GPU, true) != 0) return 1;
     std::printf("weight_residency tests passed\n");

--- a/tests/test_weight_residency.cpp
+++ b/tests/test_weight_residency.cpp
@@ -222,6 +222,97 @@ static int run_upload_rejects_wrong_context_tensor() {
     return 0;
 }
 
+static int run_upload_rejects_incomplete_store() {
+    ggml_backend_t backend = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, nullptr);
+    if (!backend) return fail("backend init failed");
+
+    ggml_init_params params = {
+        /*.mem_size   =*/ ggml_tensor_overhead() * 3,
+        /*.mem_buffer =*/ nullptr,
+        /*.no_alloc   =*/ true,
+    };
+    ggml_context * ctx = ggml_init(params);
+    if (!ctx) {
+        ggml_backend_free(backend);
+        return fail("ggml_init failed");
+    }
+
+    ggml_tensor * t0 = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, 4);
+    ggml_set_name(t0, "test.weight.0");
+    ggml_tensor * t1 = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, 4);
+    ggml_set_name(t1, "test.weight.1");
+
+    std::map<std::string, ggml_tensor *> tensors;
+    tensors["test.weight.0"] = t0;
+    tensors["test.weight.1"] = t1;
+
+    qwen3_tts::host_tensor_store store;
+    qwen3_tts::host_tensor_copy copy;
+    copy.name = "test.weight.0";
+    copy.bytes.resize(4 * sizeof(float));
+    store.total_bytes = copy.bytes.size();
+    store.tensors.push_back(copy);
+
+    ggml_backend_buffer_t buffer = nullptr;
+    std::string error;
+    const bool ok = qwen3_tts::upload_tensors_from_host(ctx, tensors, backend, store, buffer, error);
+    const bool buffer_changed = buffer != nullptr;
+
+    if (buffer) ggml_backend_buffer_free(buffer);
+    ggml_free(ctx);
+    ggml_backend_free(backend);
+
+    if (ok) return fail("upload accepted incomplete store");
+    if (error.find("missing") == std::string::npos && error.find("incomplete") == std::string::npos) {
+        return fail("incomplete store error mismatch");
+    }
+    if (buffer_changed) return fail("incomplete store failure changed buffer");
+    return 0;
+}
+
+static int run_upload_rejects_duplicate_store_name() {
+    ggml_backend_t backend = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, nullptr);
+    if (!backend) return fail("backend init failed");
+
+    ggml_init_params params = {
+        /*.mem_size   =*/ ggml_tensor_overhead() * 2,
+        /*.mem_buffer =*/ nullptr,
+        /*.no_alloc   =*/ true,
+    };
+    ggml_context * ctx = ggml_init(params);
+    if (!ctx) {
+        ggml_backend_free(backend);
+        return fail("ggml_init failed");
+    }
+
+    ggml_tensor * t = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, 4);
+    ggml_set_name(t, "test.weight");
+    std::map<std::string, ggml_tensor *> tensors;
+    tensors["test.weight"] = t;
+
+    qwen3_tts::host_tensor_store store;
+    qwen3_tts::host_tensor_copy copy;
+    copy.name = "test.weight";
+    copy.bytes.resize(4 * sizeof(float));
+    store.tensors.push_back(copy);
+    store.tensors.push_back(copy);
+    store.total_bytes = copy.bytes.size() * 2;
+
+    ggml_backend_buffer_t buffer = nullptr;
+    std::string error;
+    const bool ok = qwen3_tts::upload_tensors_from_host(ctx, tensors, backend, store, buffer, error);
+    const bool buffer_changed = buffer != nullptr;
+
+    if (buffer) ggml_backend_buffer_free(buffer);
+    ggml_free(ctx);
+    ggml_backend_free(backend);
+
+    if (ok) return fail("upload accepted duplicate store name");
+    if (error.find("duplicate") == std::string::npos) return fail("duplicate store error mismatch");
+    if (buffer_changed) return fail("duplicate store failure changed buffer");
+    return 0;
+}
+
 static int run_backend_roundtrip(enum ggml_backend_dev_type type, bool optional) {
     ggml_backend_t backend = ggml_backend_init_by_type(type, nullptr);
     if (!backend) {
@@ -280,6 +371,8 @@ int main() {
     if (run_upload_rejects_missing_destination() != 0) return 1;
     if (run_upload_rejects_non_null_buffer() != 0) return 1;
     if (run_upload_rejects_wrong_context_tensor() != 0) return 1;
+    if (run_upload_rejects_incomplete_store() != 0) return 1;
+    if (run_upload_rejects_duplicate_store_name() != 0) return 1;
     if (run_backend_roundtrip(GGML_BACKEND_DEVICE_TYPE_CPU, false) != 0) return 1;
     if (run_backend_roundtrip(GGML_BACKEND_DEVICE_TYPE_GPU, true) != 0) return 1;
     std::printf("weight_residency tests passed\n");

--- a/tests/test_weight_residency.cpp
+++ b/tests/test_weight_residency.cpp
@@ -171,6 +171,57 @@ static int run_upload_rejects_non_null_buffer() {
     return result;
 }
 
+static int run_upload_rejects_wrong_context_tensor() {
+    ggml_backend_t backend = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, nullptr);
+    if (!backend) return fail("backend init failed");
+
+    ggml_init_params params = {
+        /*.mem_size   =*/ ggml_tensor_overhead() * 2,
+        /*.mem_buffer =*/ nullptr,
+        /*.no_alloc   =*/ true,
+    };
+    ggml_context * ctx_a = ggml_init(params);
+    ggml_context * ctx_b = ggml_init(params);
+    if (!ctx_a || !ctx_b) {
+        if (ctx_a) ggml_free(ctx_a);
+        if (ctx_b) ggml_free(ctx_b);
+        ggml_backend_free(backend);
+        return fail("ggml_init failed");
+    }
+
+    ggml_tensor * ctx_a_tensor = ggml_new_tensor_1d(ctx_a, GGML_TYPE_F32, 4);
+    ggml_set_name(ctx_a_tensor, "ctx_a.weight");
+    ggml_tensor * ctx_b_tensor = ggml_new_tensor_1d(ctx_b, GGML_TYPE_F32, 4);
+    ggml_set_name(ctx_b_tensor, "test.weight");
+
+    std::map<std::string, ggml_tensor *> tensors;
+    tensors["test.weight"] = ctx_b_tensor;
+
+    qwen3_tts::host_tensor_store store;
+    qwen3_tts::host_tensor_copy copy;
+    copy.name = "test.weight";
+    copy.bytes.resize(4 * sizeof(float));
+    store.total_bytes = copy.bytes.size();
+    store.tensors.push_back(copy);
+
+    ggml_backend_buffer_t buffer = nullptr;
+    std::string error;
+    const bool ok = qwen3_tts::upload_tensors_from_host(ctx_a, tensors, backend, store, buffer, error);
+    const bool buffer_changed = buffer != nullptr;
+
+    if (buffer) ggml_backend_buffer_free(buffer);
+    ggml_free(ctx_b);
+    ggml_free(ctx_a);
+    ggml_backend_free(backend);
+
+    if (ok) return fail("upload accepted wrong-context tensor");
+    if (error.find("context") == std::string::npos && error.find("ownership") == std::string::npos) {
+        return fail("wrong-context tensor error mismatch");
+    }
+    if (buffer_changed) return fail("wrong-context failure changed buffer");
+    return 0;
+}
+
 static int run_backend_roundtrip(enum ggml_backend_dev_type type, bool optional) {
     ggml_backend_t backend = ggml_backend_init_by_type(type, nullptr);
     if (!backend) {
@@ -228,6 +279,7 @@ int main() {
     if (run_download_rejects_unallocated_tensor() != 0) return 1;
     if (run_upload_rejects_missing_destination() != 0) return 1;
     if (run_upload_rejects_non_null_buffer() != 0) return 1;
+    if (run_upload_rejects_wrong_context_tensor() != 0) return 1;
     if (run_backend_roundtrip(GGML_BACKEND_DEVICE_TYPE_CPU, false) != 0) return 1;
     if (run_backend_roundtrip(GGML_BACKEND_DEVICE_TYPE_GPU, true) != 0) return 1;
     std::printf("weight_residency tests passed\n");

--- a/tests/test_weight_residency.cpp
+++ b/tests/test_weight_residency.cpp
@@ -360,6 +360,54 @@ static int run_upload_rejects_subset_destination_map() {
     return 0;
 }
 
+static int run_upload_rejects_aliased_destination_tensor() {
+    ggml_backend_t backend = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, nullptr);
+    if (!backend) return fail("backend init failed");
+
+    ggml_init_params params = {
+        /*.mem_size   =*/ ggml_tensor_overhead() * 2,
+        /*.mem_buffer =*/ nullptr,
+        /*.no_alloc   =*/ true,
+    };
+    ggml_context * ctx = ggml_init(params);
+    if (!ctx) {
+        ggml_backend_free(backend);
+        return fail("ggml_init failed");
+    }
+
+    ggml_tensor * t = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, 4);
+    ggml_set_name(t, "test.weight");
+
+    std::map<std::string, ggml_tensor *> tensors;
+    tensors["alias.weight"] = t;
+    tensors["test.weight"] = t;
+
+    qwen3_tts::host_tensor_store store;
+    qwen3_tts::host_tensor_copy copy;
+    copy.bytes.resize(4 * sizeof(float));
+    copy.name = "alias.weight";
+    store.tensors.push_back(copy);
+    copy.name = "test.weight";
+    store.tensors.push_back(copy);
+    store.total_bytes = copy.bytes.size() * 2;
+
+    ggml_backend_buffer_t buffer = nullptr;
+    std::string error;
+    const bool ok = qwen3_tts::upload_tensors_from_host(ctx, tensors, backend, store, buffer, error);
+    const bool buffer_changed = buffer != nullptr;
+
+    if (buffer) ggml_backend_buffer_free(buffer);
+    ggml_free(ctx);
+    ggml_backend_free(backend);
+
+    if (ok) return fail("upload accepted aliased destination tensor");
+    if (error.find("duplicate") == std::string::npos && error.find("alias") == std::string::npos) {
+        return fail("aliased destination tensor error mismatch");
+    }
+    if (buffer_changed) return fail("aliased destination failure changed buffer");
+    return 0;
+}
+
 static int run_backend_roundtrip(enum ggml_backend_dev_type type, bool optional) {
     ggml_backend_t backend = ggml_backend_init_by_type(type, nullptr);
     if (!backend) {
@@ -421,6 +469,7 @@ int main() {
     if (run_upload_rejects_incomplete_store() != 0) return 1;
     if (run_upload_rejects_duplicate_store_name() != 0) return 1;
     if (run_upload_rejects_subset_destination_map() != 0) return 1;
+    if (run_upload_rejects_aliased_destination_tensor() != 0) return 1;
     if (run_backend_roundtrip(GGML_BACKEND_DEVICE_TYPE_CPU, false) != 0) return 1;
     if (run_backend_roundtrip(GGML_BACKEND_DEVICE_TYPE_GPU, true) != 0) return 1;
     std::printf("weight_residency tests passed\n");

--- a/tests/test_weight_residency.cpp
+++ b/tests/test_weight_residency.cpp
@@ -14,9 +14,11 @@ static int fail(const char * msg) {
     return 1;
 }
 
-static int run_backend_roundtrip(enum ggml_backend_dev_type type) {
+static int run_backend_roundtrip(enum ggml_backend_dev_type type, bool optional) {
     ggml_backend_t backend = ggml_backend_init_by_type(type, nullptr);
-    if (!backend) return 0; // optional backend unavailable
+    if (!backend) {
+        return optional ? 0 : fail("backend init failed");
+    }
 
     ggml_init_params params = {
         /*.mem_size   =*/ ggml_tensor_overhead() * 2,
@@ -63,8 +65,8 @@ static int run_backend_roundtrip(enum ggml_backend_dev_type type) {
 }
 
 int main() {
-    if (run_backend_roundtrip(GGML_BACKEND_DEVICE_TYPE_CPU) != 0) return 1;
-    (void) run_backend_roundtrip(GGML_BACKEND_DEVICE_TYPE_GPU);
+    if (run_backend_roundtrip(GGML_BACKEND_DEVICE_TYPE_CPU, false) != 0) return 1;
+    if (run_backend_roundtrip(GGML_BACKEND_DEVICE_TYPE_GPU, true) != 0) return 1;
     std::printf("weight_residency tests passed\n");
     return 0;
 }


### PR DESCRIPTION
## Summary

Adds idle-time RAM residency support for GPU-backed model weights so long-lived CUDA/Vulkan deployments can release VRAM between inference requests without falling back to disk reloads.

- Adds `QWEN3_TTS_GPU_OFFLOAD_IDLE_SECS` policy parsing, docs, and eligibility checks.
- Adds host residency helpers plus transformer/decoder RAM offload and reload paths.
- Adds engine lifecycle serialization around tensor users, metadata snapshots, idle worker behavior, and test-only diagnostics.
- Adds focused coverage for policy parsing, residency validation, lifecycle guarding, and pipeline idle offload behavior.

## Implementation Notes

- Production RAM offload is only eligible for CUDA/Vulkan GPU backends with resident buffer-backed tensors.
- Low-memory mode keeps the existing disk-release behavior and disables idle GPU RAM offload.
- CPU and Metal paths are treated as ineligible/no-op for this policy.
- Forced diagnostics are C++ test-only via `QWEN3_TTS_ENABLE_TEST_DIAGNOSTICS`; no C or Python API surface was added for that path.
- `load_models()` and tensor-using public paths are serialized through the engine lifecycle mutex, with metadata snapshots used for reference-returning accessors.

## Local Verification

Run locally on this branch:

```bash
cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
cmake --build build -j4
./build/test_gpu_offload_policy
./build/test_weight_residency
./build/test_audio_tokenizer_encoder_lifecycle
ctest --test-dir build -R 'gpu_offload_policy|weight_residency|audio_tokenizer_encoder_lifecycle|pipeline_offload_lifecycle|gpu_idle_offload_validation' --output-on-failure
./build/test_pipeline_offload_lifecycle
./build/test_gpu_idle_offload_validation
git diff --check
```

Results:

- `test_gpu_offload_policy`: passed.
- `test_weight_residency`: passed.
- `test_audio_tokenizer_encoder_lifecycle`: passed.
- Filtered `ctest`: 4 passed, 1 explicitly skipped (`gpu_idle_offload_validation_test` skips unless enabled).
- `test_pipeline_offload_lifecycle`: exited cleanly with a skip because local `models/` files are unavailable.
- `test_gpu_idle_offload_validation`: default skip passed; `QWEN3_TTS_RUN_GPU_OFFLOAD_VALIDATION=1 QWEN3_TTS_BACKEND=cpu` fails with the intended CUDA/Vulkan-only validation message.
- `git diff --check`: clean.
- `test_transformer` and `test_decoder` were not runnable locally because the GGUF model files are absent.

## Validation Testing Instructions

### CUDA

Build with CUDA-enabled ggml support, then build this project:

```bash
cmake -S ggml -B ggml/build -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE=Release
cmake --build ggml/build -j
cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
cmake --build build --target test_gpu_idle_offload_validation -j
```

Run the opt-in validation test with local GGUF models available:

```bash
QWEN3_TTS_RUN_GPU_OFFLOAD_VALIDATION=1 \
QWEN3_TTS_BACKEND=cuda \
QWEN3_TTS_MODEL_DIR=models \
ctest --test-dir build -R gpu_idle_offload_validation --output-on-failure
```

Expected CUDA behavior:

- VRAM rises after model load/inference.
- After the idle timeout, logs show transformer/decoder RAM offload and `nvidia-smi` shows VRAM usage drop.
- A second synthesis request succeeds and reloads from RAM, with VRAM rising again.
- No GGUF disk reload should be required for RAM-offloaded CUDA weights.

### Vulkan

Build with Vulkan-enabled ggml support:

```bash
cmake -S ggml -B ggml/build -DGGML_VULKAN=ON -DCMAKE_BUILD_TYPE=Release
cmake --build ggml/build -j
cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
cmake --build build --target test_gpu_idle_offload_validation -j
```

Run the same validation target. If there is no explicit Vulkan backend environment selector in your build, leave backend selection on `auto` and verify that Vulkan is selected by logs.

```bash
QWEN3_TTS_RUN_GPU_OFFLOAD_VALIDATION=1 \
QWEN3_TTS_MODEL_DIR=models \
ctest --test-dir build -R gpu_idle_offload_validation --output-on-failure
```

Expected Vulkan behavior:

- GPU memory usage rises during load/inference.
- After the idle timeout, logs show RAM offload and Vulkan/device memory usage drops.
- A second synthesis request succeeds after reloading weights from RAM.
- Backend logs must specifically show Vulkan for `TTSTransformer` and `AudioTokenizerDecoder`; if `auto` picks another GPU backend, rebuild/disable that backend for this validation.
- Use available platform tooling such as `nvtop`, `radeontop`, vendor GPU tools, or Vulkan memory tooling to confirm memory movement.

### Negative Checks

Validate that unsupported or conflicting modes do not use this path:

```bash
QWEN3_TTS_LOW_MEM=1 QWEN3_TTS_GPU_OFFLOAD_IDLE_SECS=2 ./build/qwen3-tts-cli -m models -t "low memory check" -o /tmp/qwen-lowmem.wav
QWEN3_TTS_BACKEND=cpu QWEN3_TTS_GPU_OFFLOAD_IDLE_SECS=1 ./build/test_pipeline_offload_lifecycle
QWEN3_TTS_RUN_GPU_OFFLOAD_VALIDATION=1 QWEN3_TTS_BACKEND=cpu ./build/test_gpu_idle_offload_validation
```

Expected negative behavior:

- Low-memory mode logs that idle GPU RAM offload is disabled and keeps the existing disk-release behavior.
- CPU lifecycle coverage should pass without production RAM offload.
- The final GPU validation guard should exit non-zero with `QWEN3_TTS_BACKEND=cpu cannot validate CUDA/Vulkan idle offload`.
- Metal/macOS auto-backend runs should be logged as ineligible/disabled for idle GPU RAM offload.

### Functional Checks

- Run two consecutive synth requests separated by more than `QWEN3_TTS_GPU_OFFLOAD_IDLE_SECS`.
- Confirm the second request produces valid audio after reloading from RAM.
- Exercise speaker embedding or preset lookup paths after an offload/reload cycle if the deployment uses voice presets.

## Known Local Gaps

- Real CUDA/Vulkan VRAM validation was not run locally in this workspace.
- The local build artifacts are CPU/Metal-oriented and the `models/` GGUF files are absent, so model-backed transformer/decoder tests could not be completed here.
