### PR TITLE
fix(quantize): keep build on C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,18 @@ find_package(Threads REQUIRED)
 # GGML library paths
 set(GGML_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ggml")
 set(GGML_BUILD_DIR "${GGML_DIR}/build")
+set(GGML_LINK_DIRS
+    ${GGML_BUILD_DIR}/src
+    ${GGML_BUILD_DIR}/src/$<CONFIG>
+    ${GGML_BUILD_DIR}/src/ggml-cpu
+    ${GGML_BUILD_DIR}/src/ggml-cpu/$<CONFIG>
+    ${GGML_BUILD_DIR}/bin
+    ${GGML_BUILD_DIR}/bin/$<CONFIG>
+)
+set(GGML_METAL_LINK_DIRS
+    ${GGML_BUILD_DIR}/src/ggml-metal
+    ${GGML_BUILD_DIR}/src/ggml-metal/$<CONFIG>
+)
 
 # Detect Metal backend availability
 if(APPLE AND EXISTS "${GGML_BUILD_DIR}/src/ggml-metal/libggml-metal.dylib")
@@ -58,8 +70,8 @@ target_include_directories(qwen3_tts_common PUBLIC
     ${GGML_DIR}/include
 )
 target_link_directories(qwen3_tts_common PUBLIC
-    ${GGML_BUILD_DIR}/src
-    ${GGML_BUILD_DIR}/src/ggml-metal
+    ${GGML_LINK_DIRS}
+    ${GGML_METAL_LINK_DIRS}
 )
 target_link_libraries(qwen3_tts_common PUBLIC
     ggml
@@ -136,8 +148,22 @@ target_link_libraries(qwen3-tts-cli PRIVATE
 add_executable(qwen3-tts-quantize
     src/qwen3_tts_quantize.cpp
 )
+target_compile_features(qwen3-tts-quantize PRIVATE cxx_std_17)
+set_target_properties(qwen3-tts-quantize PROPERTIES
+    CXX_EXTENSIONS OFF
+)
+target_include_directories(qwen3-tts-quantize PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+    ${GGML_DIR}/include
+)
+target_link_directories(qwen3-tts-quantize PRIVATE
+    ${GGML_LINK_DIRS}
+)
 target_link_libraries(qwen3-tts-quantize PRIVATE
-    qwen3_tts_common
+    ggml
+    ggml-base
+    ggml-cpu
+    Threads::Threads
 )
 
 # Test executable for tokenizer

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Runs the full TTS pipeline in pure C++17, including text tokenization, speaker e
 
 ## Prerequisites
 
-- **Compiler:** GCC 9+ or Clang 10+ (Linux/macOS), or MSVC 2019+ (Windows)
+- **Compiler:** C++17-capable GCC 9+ or Clang 10+ (Linux/macOS), or MSVC 2019+ (Windows)
 - **CMake:** 3.14+
 - **GGML:** Built from source (vendored as git submodule)
 - **GPU backends (optional):**
@@ -408,6 +408,18 @@ Quantize models from F16 to smaller formats without Python:
 ```
 
 Supported types: `q8_0`, `q4_0`, `q4_1`, `q5_0`, `q5_1`, `q4_k`, `q5_k`, `q6_k`. The CLI auto-detects Q8_0 models when present.
+
+The quantizer is built as a C++17 target by default; no C++20 compiler mode is required. To build only the quantizer after building GGML:
+
+```bash
+cmake --build build --target qwen3-tts-quantize -j4
+```
+
+On Windows, run this from a Developer Command Prompt:
+
+```cmd
+cmake --build build --target qwen3-tts-quantize --config Release
+```
 
 ### Backend Selection
 

--- a/src/qwen3_tts_quantize.cpp
+++ b/src/qwen3_tts_quantize.cpp
@@ -3,8 +3,6 @@
 // Usage: qwen3-tts-quantize --input <path> --output <path> --type <q8_0|q4_k|q4_0|q5_0|q5_1>
 //        [--exclude <pattern>]  (keep matching tensors at original precision)
 
-#include "common/gguf_loader.h"
-
 #include "ggml.h"
 #include "ggml-backend.h"
 #include "gguf.h"


### PR DESCRIPTION
## Summary
- keep `qwen3-tts-quantize` on an explicit C++17 target
- link the quantizer directly against GGML and include Windows multi-config GGML library paths
- document the C++17 quantizer target and target-only build commands for local and Windows builds

## Verification
- `cl /nologo /std:c++17 /EHsc /Zs /I src /I ggml\include src\qwen3_tts_quantize.cpp`
- `git diff --check -- CMakeLists.txt README.md src/qwen3_tts_quantize.cpp`