### PR TITLE
Add cross-platform qwen3-tts performance controls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,7 +279,7 @@ add_executable(test_backend_threads
     tests/test_backend_threads.cpp
 )
 target_link_libraries(test_backend_threads PRIVATE
-    qwen3_tts_common
+    qwen3_tts
     Threads::Threads
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,13 @@ else()
 endif()
 
 # Common library (gguf_loader + coreml bridge — compiled once, shared by all)
-set(COMMON_SOURCES src/common/gguf_loader.cpp src/common/speaker_embedding_io.cpp src/common/gpu_offload_policy.cpp src/common/weight_residency.cpp)
+set(COMMON_SOURCES
+    src/common/benchmark_json.cpp
+    src/common/gguf_loader.cpp
+    src/common/gpu_offload_policy.cpp
+    src/common/speaker_embedding_io.cpp
+    src/common/weight_residency.cpp
+)
 if(APPLE AND QWEN3_TTS_COREML)
     list(APPEND COMMON_SOURCES src/common/coreml_code_predictor.mm)
     set_source_files_properties(src/common/coreml_code_predictor.mm PROPERTIES COMPILE_FLAGS "-fobjc-arc")
@@ -258,6 +264,15 @@ target_compile_definitions(test_gpu_idle_offload_validation PRIVATE
     QWEN3_TTS_ENABLE_TEST_DIAGNOSTICS
 )
 
+# Test executable for benchmark JSON helper
+add_executable(test_benchmark_json
+    tests/test_benchmark_json.cpp
+)
+target_link_libraries(test_benchmark_json PRIVATE
+    qwen3_tts_common
+    Threads::Threads
+)
+
 # Install targets
 install(TARGETS text_tokenizer tts_transformer audio_tokenizer_encoder audio_codec_encoder audio_tokenizer_decoder qwen3_tts qwen3tts_shared qwen3-tts-cli
     ARCHIVE DESTINATION lib
@@ -319,4 +334,9 @@ add_test(NAME gpu_idle_offload_validation_test
 set_tests_properties(gpu_idle_offload_validation_test PROPERTIES
     LABELS "manual;gpu"
     SKIP_REGULAR_EXPRESSION "SKIP:"
+)
+
+add_test(NAME benchmark_json_test
+    COMMAND test_benchmark_json
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ endif()
 
 # Common library (gguf_loader + coreml bridge — compiled once, shared by all)
 set(COMMON_SOURCES
+    src/common/backend_threads.cpp
     src/common/benchmark_json.cpp
     src/common/gguf_loader.cpp
     src/common/gpu_offload_policy.cpp
@@ -273,6 +274,15 @@ target_link_libraries(test_benchmark_json PRIVATE
     Threads::Threads
 )
 
+# Test executable for backend thread helper
+add_executable(test_backend_threads
+    tests/test_backend_threads.cpp
+)
+target_link_libraries(test_backend_threads PRIVATE
+    qwen3_tts_common
+    Threads::Threads
+)
+
 # Install targets
 install(TARGETS text_tokenizer tts_transformer audio_tokenizer_encoder audio_codec_encoder audio_tokenizer_decoder qwen3_tts qwen3tts_shared qwen3-tts-cli
     ARCHIVE DESTINATION lib
@@ -280,6 +290,7 @@ install(TARGETS text_tokenizer tts_transformer audio_tokenizer_encoder audio_cod
     RUNTIME DESTINATION bin
 )
 install(FILES
+    src/common/backend_threads.h
     src/common/gguf_loader.h
     src/common/gpu_offload_policy.h
     src/common/weight_residency.h
@@ -338,5 +349,9 @@ set_tests_properties(gpu_idle_offload_validation_test PROPERTIES
 
 add_test(NAME benchmark_json_test
     COMMAND test_benchmark_json
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+add_test(NAME backend_threads_test
+    COMMAND test_backend_threads
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )

--- a/README.md
+++ b/README.md
@@ -375,6 +375,30 @@ python scripts/convert_tts_to_gguf.py \
 
 Base variants (`-Base` on HF) carry no preset list — use voice cloning via `-r reference.wav` instead. The Python server's `/v1/audio/voices` endpoint lists both local JSON embeddings (from `voices/`) and model-level presets; `/v1/audio/speech` accepts either kind in the `voice` field.
 
+### Fine-Tuned Custom Voices
+
+If you want to train your own reusable preset speaker rather than using the stock CustomVoice checkpoints, see [docs/fine-tuning-custom-voices.md](./docs/fine-tuning-custom-voices.md).
+
+The supported path today is:
+
+1. fine-tune `Qwen/Qwen3-TTS-12Hz-1.7B-Base` with the upstream `QwenLM/Qwen3-TTS` fine-tuning scripts
+2. convert the selected checkpoint to GGUF with `scripts/convert_tts_to_gguf.py`
+3. load it explicitly with `--tts-model <file>` in `qwen3-tts.cpp`
+
+Example validation flow:
+
+```bash
+./build/qwen3-tts-cli -m models \
+  --tts-model qwen3-tts-1.7b-my-voice-f16.gguf \
+  --list-speakers
+
+./build/qwen3-tts-cli -m models \
+  --tts-model qwen3-tts-1.7b-my-voice-f16.gguf \
+  --speaker my_voice -t "Hello from my fine-tuned voice." -o out.wav
+```
+
+Do not rely on default model auto-detection for fine-tuned checkpoints, and do not assume the current Python server or C API can select arbitrary fine-tuned TTS model filenames cleanly.
+
 ### Speaker Embedding Workflow
 
 Precompute a speaker embedding once (saves ~20s per synthesis):

--- a/README.md
+++ b/README.md
@@ -315,6 +315,8 @@ Place both `.gguf` files in a `models/` directory.
 | `--max-tokens <n>` | Maximum audio frames (codec tokens) to generate | 2048 |
 | `--repetition-penalty <val>` | Repetition penalty on codebook-0 token generation | 1.05 |
 | `--seed <n>` | RNG seed for reproducible output | (random) |
+| `--benchmark-json <file>` | Write structured timing, model, backend, and memory metrics after synthesis | (none) |
+| `--quiet-progress` | Suppress progress/status/timing logs for benchmark runs | off |
 | `--no-f32-acc` | Disable f32 matmul accumulation (faster, less precise) | (off) |
 | `-l, --language <lang>` | Language: en, ru, zh, ja, ko, de, fr, es | en |
 | `-j, --threads <n>` | Number of compute threads | 4 |
@@ -523,6 +525,12 @@ Low-memory mode should log that idle GPU RAM offload is disabled and keep the ex
 | `QWEN3_TTS_USE_COREML` | `1` on macOS when model exists | Set to `0` to disable the CoreML code-predictor bridge without rebuilding. |
 | `QWEN3_TTS_COREML_MODEL` | auto-detected | Absolute path override for a custom `.mlpackage` location (macOS only). |
 
+### Thread controls
+
+The CLI `-j/--threads`, C API `qwen3_tts_create(model_dir, n_threads)`, and server `QWEN3TTS_THREADS` setting configure the engine's default GGML compute thread count. They apply to CPU backends and to GGML backends that expose a thread setter. GPU-only work may ignore this setting.
+
+For C API per-call parameters, `Qwen3TtsParams.n_threads == 0` means "use the engine default". Set a positive value only when a specific call should override the handle default.
+
 ## C API
 
 The shared library `libqwen3tts.{so,dylib,dll}` is built automatically by CMake (the `qwen3tts_shared` target). It provides a C-linkage API for FFI integration from Python, Rust, Nim, Go, etc.
@@ -535,7 +543,7 @@ typedef struct Qwen3TtsParams {
     float   temperature;         // default: 0.9, 0=greedy
     float   top_p;               // default: 1.0
     int32_t top_k;               // default: 50, 0=disabled
-    int32_t n_threads;           // default: 4
+    int32_t n_threads;           // default: 0 (use handle default)
     float   repetition_penalty;  // default: 1.05
     int32_t language_id;         // 2050=en, 2058=ja, 2055=zh, etc.
 } Qwen3TtsParams;
@@ -557,6 +565,10 @@ typedef struct Qwen3TtsAudio {
 | `qwen3_tts_synthesize(tts, text, params)` | Text to audio |
 | `qwen3_tts_synthesize_with_voice_file(tts, text, wav_path, params)` | Voice clone from WAV |
 | `qwen3_tts_synthesize_with_voice_samples(tts, text, samples, n, params)` | Voice clone from float32 |
+| `qwen3_tts_synthesize_icl_file(tts, text, wav_path, ref_text, params)` | ICL voice cloning from WAV plus transcript |
+| `qwen3_tts_prepare_icl_prompt_file(tts, wav_path, ref_text, params)` | Prepare reusable ICL reference prompt state |
+| `qwen3_tts_synthesize_with_icl_prompt(tts, text, prompt, params)` | Synthesize using a prepared ICL prompt |
+| `qwen3_tts_free_icl_prompt(prompt)` | Free a prepared ICL prompt handle |
 | `qwen3_tts_extract_embedding_file(tts, wav_path, buf, max)` | Extract speaker embedding |
 | `qwen3_tts_synthesize_with_embedding(tts, text, emb, size, params)` | Synthesize with cached embedding |
 | `qwen3_tts_sample_rate(tts)` | Returns 24000 |
@@ -592,6 +604,7 @@ A full Python binding is provided in `server/qwen3_tts_binding.py`. See the [Ser
 ### Memory Management
 
 - Every `Qwen3TtsAudio*` returned by synthesis functions must be freed with `qwen3_tts_free_audio()`
+- Every `Qwen3TtsIclPrompt*` returned by `qwen3_tts_prepare_icl_prompt_file()` must be freed with `qwen3_tts_free_icl_prompt()`. Prepared prompts are tied to compatible model dimensions and should not be shared across different engines or model layouts.
 - The engine handle must be destroyed with `qwen3_tts_destroy()`
 - The `qwen3_tts_get_error()` string is owned by the engine and valid until the next API call
 
@@ -698,6 +711,28 @@ Example output (92 frames, 7.3s audio):
 ```
 
 The code predictor (15 sequential forward passes per frame) accounts for ~71% of generation time.
+
+### Structured benchmark output
+
+For repeatable local comparisons across macOS, Linux, and Windows, write a JSON record from the CLI:
+
+```bash
+cmake -S . -B build-perf -DQWEN3_TTS_TIMING=ON
+cmake --build build-perf -j4
+
+./build-perf/qwen3-tts-cli \
+  -m models \
+  -t "Benchmark smoke test." \
+  --seed 1234 \
+  --max-tokens 64 \
+  --benchmark-json bench.json \
+  --quiet-progress \
+  -o bench.wav
+```
+
+The JSON includes the synthesis mode, selected backend/device, thread count, model metadata, output audio duration, wall-clock phase timings, memory counters, `speed_x_realtime`, and `wall_rtf`. When built with `QWEN3_TTS_TIMING=ON`, it also includes detailed graph build, graph allocation, compute, and data-transfer timing fields.
+
+In local gating for graph-lifecycle reuse, the 0.6B Q8_0 BLAS path spent about 17 ms in code-predictor graph build/allocation during a 999 ms generation step. That made graph reservation a low-impact optimization for this repo at the time of measurement, so there is no user-facing graph-reservation knob documented here.
 
 ## Troubleshooting
 

--- a/docs/fine-tuning-custom-voices.md
+++ b/docs/fine-tuning-custom-voices.md
@@ -1,0 +1,388 @@
+# Fine-Tuning Custom Voices for `qwen3-tts.cpp`
+
+This guide documents the best currently supportable path for creating a reusable custom voice for `qwen3-tts.cpp`.
+
+The supported workflow is:
+
+1. Fine-tune `Qwen/Qwen3-TTS-12Hz-1.7B-Base` with the official upstream training scripts from [QwenLM/Qwen3-TTS](https://github.com/QwenLM/Qwen3-TTS/tree/main/finetuning)
+2. Pick the best checkpoint by listening to multiple epochs
+3. Convert the chosen checkpoint to GGUF with [`scripts/convert_tts_to_gguf.py`](../scripts/convert_tts_to_gguf.py)
+4. Validate the resulting GGUF in `qwen3-tts.cpp` with `--list-speakers` and `--speaker <name>`
+
+This document was verified against upstream `QwenLM/Qwen3-TTS` fine-tuning files on April 22, 2026:
+
+- [upstream finetuning README](https://raw.githubusercontent.com/QwenLM/Qwen3-TTS/main/finetuning/README.md)
+- [upstream `prepare_data.py`](https://raw.githubusercontent.com/QwenLM/Qwen3-TTS/main/finetuning/prepare_data.py)
+- [upstream `sft_12hz.py`](https://raw.githubusercontent.com/QwenLM/Qwen3-TTS/main/finetuning/sft_12hz.py)
+- [upstream `dataset.py`](https://raw.githubusercontent.com/QwenLM/Qwen3-TTS/main/finetuning/dataset.py)
+
+## Support Matrix
+
+### Supported
+
+- Single-speaker fine-tuning
+- `Qwen/Qwen3-TTS-12Hz-1.7B-Base`
+- Linux + NVIDIA CUDA for training
+- GGUF conversion in `qwen3-tts.cpp`
+- Local inference validation in `qwen3-tts.cpp`
+
+### Best-effort only
+
+- macOS / Apple Silicon for helper tasks such as file preparation, GGUF conversion, and local inference checks
+
+### Not supported in this guide
+
+- `0.6B` fine-tuning
+- Multi-speaker fine-tuning
+- Native training inside `qwen3-tts.cpp`
+- Assuming the Python server or C API will automatically pick up arbitrary fine-tuned model filenames
+
+## Important Constraints
+
+### 1. Train on Linux/CUDA
+
+The upstream fine-tuning scripts are CUDA-first. The official examples use `--device cuda:0`, and the model-loading path in `sft_12hz.py` is written around GPU inference/training.
+
+Treat Linux + NVIDIA CUDA as the supported path for actual fine-tuning.
+
+### 2. Use `1.7B-Base`, not `0.6B`
+
+The upstream repo advertises fine-tuning for both `1.7B` and `0.6B`, but as of April 22, 2026 there is still an open upstream issue for `0.6B` dimension mismatch during fine-tuning:
+
+- [Issue #198](https://github.com/QwenLM/Qwen3-TTS/issues/198)
+
+For a stable workflow, use `Qwen/Qwen3-TTS-12Hz-1.7B-Base`.
+
+### 3. The fine-tuned model behaves like a single preset CustomVoice model
+
+The current upstream `sft_12hz.py` script:
+
+- rewrites `config.json` so `tts_model_type` becomes `custom_voice`
+- writes your `speaker_name` into `talker_config.spk_id`
+- assigns that speaker to token id `3000`
+- copies the learned target speaker embedding into codec embedding row `3000`
+- drops `speaker_encoder.*` weights when saving the fine-tuned checkpoint
+
+That means the safest way to use the resulting model in `qwen3-tts.cpp` is as a preset speaker model:
+
+- validate it with `--list-speakers`
+- synthesize with `--speaker <name>`
+
+Do not assume the fine-tuned checkpoint will behave like the stock Base checkpoint for all reference-audio cloning paths.
+
+### 4. Do not rely on default model auto-detection
+
+`qwen3-tts.cpp` auto-detection still defaults to stock `qwen3-tts-0.6b-{q8_0,f16}.gguf` filenames. For a fine-tuned model, always load it explicitly with:
+
+```bash
+--tts-model your-model-name.gguf
+```
+
+## Environment Setup
+
+### Linux / NVIDIA CUDA training environment
+
+Start from a clean Python virtual environment on a CUDA-capable Linux machine.
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+pip install qwen-tts accelerate tensorboard soundfile librosa safetensors
+git clone https://github.com/QwenLM/Qwen3-TTS.git
+cd Qwen3-TTS/finetuning
+```
+
+Notes:
+
+- `qwen-tts` is the required upstream package.
+- `accelerate` is imported by `sft_12hz.py`.
+- `tensorboard` is a practical dependency because the upstream script initializes `Accelerator(..., log_with="tensorboard")`.
+- If your environment already pins these packages differently, isolate the fine-tuning workflow in its own virtual environment.
+
+### macOS / Apple Silicon
+
+Do not treat Apple Silicon as the primary training environment for this workflow.
+
+What macOS is useful for in this guide:
+
+- preparing JSONL manifests
+- organizing checkpoints
+- converting a selected checkpoint to GGUF
+- running local `qwen3-tts.cpp` CLI validation
+
+What this guide does **not** claim:
+
+- that upstream `prepare_data.py` has been validated on `cpu` or `mps`
+- that local fine-tuning on macOS is a supported path
+
+## Dataset Format
+
+The upstream fine-tuning README expects a JSONL file with one JSON object per line.
+
+Each line must contain:
+
+- `audio`: path to the target training WAV
+- `text`: transcript for that WAV
+- `ref_audio`: path to the reference speaker WAV
+
+Example:
+
+```jsonl
+{"audio":"./data/utt0001.wav","text":"Actually, I have realized that I pay close attention to other people's emotions.","ref_audio":"./data/ref.wav"}
+{"audio":"./data/utt0002.wav","text":"She said she would be here by noon.","ref_audio":"./data/ref.wav"}
+```
+
+Upstream specifically recommends using the **same** `ref_audio` for every training sample because that usually improves speaker consistency and stability.
+
+Practical guidance:
+
+- Keep every clip to a single speaker
+- Make sure transcripts match the audio exactly
+- Use a clean reference clip for `ref_audio`
+- Keep the training data language and the transcripts aligned
+- Store paths in a way that will still resolve from the `finetuning/` working directory
+
+## Prepare Data
+
+The upstream preprocessing step adds `audio_codes` to each JSONL record.
+
+Run:
+
+```bash
+python prepare_data.py \
+  --device cuda:0 \
+  --tokenizer_model_path Qwen/Qwen3-TTS-Tokenizer-12Hz \
+  --input_jsonl train_raw.jsonl \
+  --output_jsonl train_with_codes.jsonl
+```
+
+Input:
+
+- `train_raw.jsonl` with `audio`, `text`, and `ref_audio`
+
+Output:
+
+- `train_with_codes.jsonl` with an added `audio_codes` field
+
+The official `prepare_data.py` processes `audio` through the `Qwen3TTSTokenizer` and writes `audio_codes` back into the JSONL output.
+
+## Fine-Tune the Base Model
+
+The official training entry point is `sft_12hz.py`.
+
+Minimal command:
+
+```bash
+python sft_12hz.py \
+  --init_model_path Qwen/Qwen3-TTS-12Hz-1.7B-Base \
+  --output_model_path output \
+  --train_jsonl train_with_codes.jsonl \
+  --batch_size 32 \
+  --lr 2e-6 \
+  --num_epochs 10 \
+  --speaker_name my_voice
+```
+
+Important notes:
+
+- `speaker_name` is the name that should later appear in `qwen3-tts.cpp --list-speakers`
+- the upstream README uses `batch_size 32`, but that is only realistic on large GPUs
+- if you hit memory pressure, reduce `--batch_size` first
+
+Checkpoints are written as:
+
+- `output/checkpoint-epoch-0`
+- `output/checkpoint-epoch-1`
+- `output/checkpoint-epoch-2`
+- ...
+
+## Evaluate and Select a Checkpoint Before Export
+
+Do **not** assume the final epoch is automatically the best checkpoint.
+
+There is an open upstream report showing speaking-rate drift across epochs during Base fine-tuning:
+
+- [Issue #179](https://github.com/QwenLM/Qwen3-TTS/issues/179)
+
+Before you convert anything to GGUF:
+
+1. Pick a fixed evaluation sentence or short paragraph
+2. Run the same inference against multiple checkpoint directories
+3. Listen for:
+   - speaker similarity
+   - noise or collapse
+   - speaking-rate drift
+   - pronunciation stability
+4. Select the best checkpoint by listening, not by epoch number alone
+
+The upstream README’s quick inference pattern is:
+
+```python
+import torch
+import soundfile as sf
+from qwen_tts import Qwen3TTSModel
+
+device = "cuda:0"
+tts = Qwen3TTSModel.from_pretrained(
+    "output/checkpoint-epoch-2",
+    device_map=device,
+    dtype=torch.bfloat16,
+    attn_implementation="flash_attention_2",
+)
+
+wavs, sr = tts.generate_custom_voice(
+    text="She said she would be here by noon.",
+    speaker="my_voice",
+)
+sf.write("output.wav", wavs[0], sr)
+```
+
+If you want to compare many checkpoints quickly, adapt that snippet into a loop and render one WAV per checkpoint.
+
+## Convert the Chosen Checkpoint to GGUF
+
+After you choose the best checkpoint, switch back to your `qwen3-tts.cpp` checkout and convert it.
+
+Example:
+
+```bash
+cd /path/to/qwen3-tts.cpp
+python scripts/convert_tts_to_gguf.py \
+  --input /path/to/Qwen3-TTS/finetuning/output/checkpoint-epoch-4 \
+  --output models/qwen3-tts-1.7b-my-voice-f16.gguf \
+  --type f16
+```
+
+Recommended naming:
+
+- `models/qwen3-tts-1.7b-my-voice-f16.gguf`
+
+The vocoder/tokenizer GGUF is **not** re-trained by this workflow, so keep using the standard tokenizer/vocoder model:
+
+- `models/qwen3-tts-tokenizer-f16.gguf`
+
+If you have not prepared the standard runtime models yet, use the repo setup flow first:
+
+```bash
+python scripts/setup_pipeline_models.py
+```
+
+That gives you:
+
+- `models/qwen3-tts-0.6b-f16.gguf`
+- `models/qwen3-tts-tokenizer-f16.gguf`
+- optional CoreML artifacts on macOS
+
+For a fine-tuned workflow, you replace only the TTS GGUF you point at with `--tts-model`.
+
+## Validate the Fine-Tuned Model in `qwen3-tts.cpp`
+
+This is the minimum validation sequence that proves you produced a reusable custom voice.
+
+### 1. Confirm the speaker metadata is present
+
+```bash
+./build/qwen3-tts-cli \
+  -m models \
+  --tts-model qwen3-tts-1.7b-my-voice-f16.gguf \
+  --list-speakers
+```
+
+Expected result:
+
+- the model loads successfully
+- your `speaker_name` appears in the preset speaker list
+
+If your name does **not** appear, stop there. The conversion did not preserve the speaker metadata you need for preset-speaker inference.
+
+### 2. Run a real synthesis test with the trained speaker
+
+```bash
+./build/qwen3-tts-cli \
+  -m models \
+  --tts-model qwen3-tts-1.7b-my-voice-f16.gguf \
+  --speaker my_voice \
+  -t "This is a validation sentence for my fine-tuned voice." \
+  -o out-my-voice.wav
+```
+
+Expected result:
+
+- synthesis completes without error
+- the output sounds like the intended speaker
+- the speaking rate and pronunciation are acceptable
+
+### 3. Keep using explicit model selection
+
+For fine-tuned checkpoints, keep `--tts-model qwen3-tts-1.7b-my-voice-f16.gguf` in your commands. Do not rely on default model discovery.
+
+## Recommended Runtime Layout
+
+Example `models/` directory:
+
+```text
+models/
+  qwen3-tts-tokenizer-f16.gguf
+  qwen3-tts-0.6b-f16.gguf
+  qwen3-tts-1.7b-my-voice-f16.gguf
+```
+
+The tokenizer/vocoder GGUF remains shared. Only the TTS model file changes.
+
+## Known Limitations
+
+- This guide only covers single-speaker fine-tuning.
+- It does not cover `0.6B` fine-tuning.
+- It does not claim that the Python server can select arbitrary fine-tuned TTS model files by name.
+- It does not claim that the C API can load arbitrary fine-tuned TTS model names without code changes.
+- It does not guarantee that reference-audio cloning through the fine-tuned checkpoint will match the stock Base model behavior.
+- Upstream fine-tuning quality can vary across epochs, so checkpoint selection matters.
+
+## Troubleshooting
+
+### `speaker_name` does not appear in `--list-speakers`
+
+Possible causes:
+
+- you converted the wrong checkpoint directory
+- the checkpoint was saved before `config.json` was rewritten with `tts_model_type=custom_voice` and `spk_id`
+- conversion was run against a directory that did not contain the modified `config.json`
+
+Re-check the chosen checkpoint directory before conversion.
+
+### The model loads, but `--speaker my_voice` fails
+
+Possible causes:
+
+- the `speaker_name` in training does not match the name you are passing
+- the GGUF speaker metadata does not match the checkpoint config
+
+Run `--list-speakers` first and use the exact name shown there.
+
+### The voice sounds worse in later epochs
+
+This is a known risk in the upstream workflow. Compare multiple checkpoints and convert the one that sounds best instead of always taking the latest epoch.
+
+Relevant upstream report:
+
+- [Issue #179](https://github.com/QwenLM/Qwen3-TTS/issues/179)
+
+### You tried to fine-tune `0.6B`
+
+Switch to `1.7B-Base`. There is still an open upstream `0.6B` fine-tuning issue:
+
+- [Issue #198](https://github.com/QwenLM/Qwen3-TTS/issues/198)
+
+### You want to use the fine-tuned model through the server
+
+Validate the model with the CLI first. The current server path in `qwen3-tts.cpp` still assumes stock model naming and does not expose clean per-request TTS model selection.
+
+## References
+
+- [QwenLM/Qwen3-TTS repository](https://github.com/QwenLM/Qwen3-TTS)
+- [official finetuning README](https://raw.githubusercontent.com/QwenLM/Qwen3-TTS/main/finetuning/README.md)
+- [official `prepare_data.py`](https://raw.githubusercontent.com/QwenLM/Qwen3-TTS/main/finetuning/prepare_data.py)
+- [official `sft_12hz.py`](https://raw.githubusercontent.com/QwenLM/Qwen3-TTS/main/finetuning/sft_12hz.py)
+- [Issue #179: speaking-rate drift across epochs](https://github.com/QwenLM/Qwen3-TTS/issues/179)
+- [Issue #198: `0.6B` fine-tuning mismatch](https://github.com/QwenLM/Qwen3-TTS/issues/198)

--- a/docs/plans/2026-04-22-fine-tuning-custom-voices-design.md
+++ b/docs/plans/2026-04-22-fine-tuning-custom-voices-design.md
@@ -1,0 +1,130 @@
+# Fine-Tuning Custom Voices Guide Design
+
+## Goal
+
+Add end-user documentation that explains the best supported path for creating custom fine-tuned voices for `qwen3-tts.cpp`.
+
+The guide should standardize on the upstream `QwenLM/Qwen3-TTS` fine-tuning workflow for `Qwen3-TTS-12Hz-1.7B-Base`, then show how to convert the resulting checkpoint to GGUF and validate it in `qwen3-tts.cpp`.
+
+## Audience
+
+This documentation is for end users who need a practical recipe from dataset preparation through fine-tuning, GGUF conversion, and inference.
+
+It is not aimed at repository maintainers only, and it is not meant to describe how to build a native training stack inside `qwen3-tts.cpp`.
+
+## Supported Scope
+
+### Supported
+
+- Single-speaker fine-tuning
+- `Qwen/Qwen3-TTS-12Hz-1.7B-Base` as the training base model
+- Linux with NVIDIA CUDA as the supported training environment
+- macOS / Apple Silicon for dataset preparation, GGUF conversion, and local inference validation
+- Explicit `--tts-model <file>` loading when running fine-tuned checkpoints in `qwen3-tts.cpp`
+
+### Out of Scope
+
+- `0.6B` fine-tuning
+- Multi-speaker fine-tuning
+- Native training implementation in `qwen3-tts.cpp`
+- Claiming full server or C API support for arbitrary fine-tuned checkpoint names
+
+## Why This Path
+
+`qwen3-tts.cpp` is an inference and model-conversion project, not a training project. The upstream `QwenLM/Qwen3-TTS` repository now ships an official fine-tuning workflow under `finetuning/`, including `prepare_data.py`, `dataset.py`, and `sft_12hz.py`.
+
+The runtime in this repository already supports consuming converted CustomVoice-style GGUF checkpoints when users load them explicitly, but the default server and C API paths still assume stock model filenames. The guide should therefore standardize on upstream training plus local conversion and CLI validation, rather than implying that this repository owns the training workflow end to end.
+
+## Documentation Deliverables
+
+### 1. New guide
+
+Create a new document at:
+
+- `docs/fine-tuning-custom-voices.md`
+
+This guide will be a runbook rather than a high-level overview. It should include:
+
+- Goal and support matrix
+- Prerequisites and environment expectations
+- Dataset requirements for single-speaker fine-tuning
+- Linux/CUDA setup for training
+- macOS limitations and what users can still do on Apple Silicon
+- Upstream fine-tuning steps
+- GGUF conversion steps using `scripts/convert_tts_to_gguf.py`
+- Validation steps in `qwen3-tts.cpp`
+- Known limitations and troubleshooting notes
+
+### 2. README integration
+
+Add a short subsection to `README.md` near the existing CustomVoice / VoiceDesign material that:
+
+- points readers to `docs/fine-tuning-custom-voices.md`
+- tells users to load fine-tuned checkpoints with `--tts-model <file>`
+- does not overstate current server-side support
+
+## Guide Structure
+
+The guide should use the following structure:
+
+1. Overview
+2. What is supported
+3. Training environment
+4. Dataset format and recommendations
+5. Upstream data preparation
+6. Upstream fine-tuning
+7. Exporting a fine-tuned checkpoint to GGUF
+8. Running the fine-tuned model in `qwen3-tts.cpp`
+9. Validation checklist
+10. Known limitations
+11. Troubleshooting
+
+## Key Technical Constraints To Document
+
+### Training support
+
+The guide should recommend `1.7B-Base` only. As of February 10, 2026, the upstream public issue tracker still showed an open `0.6B` fine-tuning dimension mismatch issue, so `0.6B` should remain out of scope for the supported path.
+
+### Model loading in this repo
+
+Fine-tuned checkpoints should be loaded explicitly with `--tts-model`, because auto-detection currently defaults to stock `qwen3-tts-0.6b-{q8_0,f16}.gguf` naming.
+
+### Speaker encoder expectations
+
+The guide should warn that a fine-tuned checkpoint may work for preset-speaker synthesis while not supporting the legacy speaker-encoder cloning path in the same way as the stock base checkpoint. Users should validate the exact inference path they intend to use.
+
+### Server and C API limitations
+
+The guide should not claim that the Python server or C API can automatically discover arbitrary fine-tuned model names. For now, the cleanly supported validation path is the CLI with explicit model selection.
+
+## Validation Requirements
+
+Before the documentation work is considered complete:
+
+- The new guide should be checked for consistency with the upstream fine-tuning README and scripts
+- The README link should land near the existing voice-related sections
+- The commands shown for `qwen3-tts.cpp` should reflect current local behavior, especially explicit `--tts-model` loading
+- The guide should distinguish supported behavior from best-effort or known-limited behavior
+
+## Non-Goals
+
+- No code changes to training logic
+- No server feature additions
+- No model selection API redesign
+- No wrapper scripts around the upstream training repo in this pass
+
+## Risks
+
+- Upstream fine-tuning scripts may continue to evolve, so commands and assumptions may drift over time
+- Some users will expect macOS local training; the guide must be explicit that Linux/CUDA is the supported training path
+- Users may assume “fine-tuned custom voices” means the same runtime behavior as the stock CustomVoice releases; the guide should call out where that assumption is unsafe
+
+## Recommendation
+
+Proceed with a documentation-only implementation that standardizes:
+
+- upstream `Qwen3-TTS-12Hz-1.7B-Base` fine-tuning
+- local GGUF conversion in `qwen3-tts.cpp`
+- CLI-based validation with explicit model selection
+
+This gives users the best currently supportable path without overstating what `qwen3-tts.cpp` owns today.

--- a/docs/plans/2026-04-22-fine-tuning-custom-voices-design.md
+++ b/docs/plans/2026-04-22-fine-tuning-custom-voices-design.md
@@ -19,7 +19,7 @@ It is not aimed at repository maintainers only, and it is not meant to describe 
 - Single-speaker fine-tuning
 - `Qwen/Qwen3-TTS-12Hz-1.7B-Base` as the training base model
 - Linux with NVIDIA CUDA as the supported training environment
-- macOS / Apple Silicon for dataset preparation, GGUF conversion, and local inference validation
+- macOS / Apple Silicon for GGUF conversion and local inference validation
 - Explicit `--tts-model <file>` loading when running fine-tuned checkpoints in `qwen3-tts.cpp`
 
 ### Out of Scope
@@ -50,9 +50,10 @@ This guide will be a runbook rather than a high-level overview. It should includ
 - Dataset requirements for single-speaker fine-tuning
 - Linux/CUDA setup for training
 - macOS limitations and what users can still do on Apple Silicon
+- checkpoint evaluation and selection before conversion
 - Upstream fine-tuning steps
 - GGUF conversion steps using `scripts/convert_tts_to_gguf.py`
-- Validation steps in `qwen3-tts.cpp`
+- Validation steps in `qwen3-tts.cpp`, including explicit speaker validation
 - Known limitations and troubleshooting notes
 
 ### 2. README integration
@@ -73,11 +74,12 @@ The guide should use the following structure:
 4. Dataset format and recommendations
 5. Upstream data preparation
 6. Upstream fine-tuning
-7. Exporting a fine-tuned checkpoint to GGUF
-8. Running the fine-tuned model in `qwen3-tts.cpp`
-9. Validation checklist
-10. Known limitations
-11. Troubleshooting
+7. Checkpoint evaluation and selection
+8. Exporting a fine-tuned checkpoint to GGUF
+9. Running the fine-tuned model in `qwen3-tts.cpp`
+10. Validation checklist
+11. Known limitations
+12. Troubleshooting
 
 ## Key Technical Constraints To Document
 
@@ -89,9 +91,17 @@ The guide should recommend `1.7B-Base` only. As of February 10, 2026, the upstre
 
 Fine-tuned checkpoints should be loaded explicitly with `--tts-model`, because auto-detection currently defaults to stock `qwen3-tts-0.6b-{q8_0,f16}.gguf` naming.
 
+### Checkpoint selection
+
+The guide should not imply that the latest epoch is automatically the best output. Before GGUF conversion, users should evaluate multiple upstream checkpoints and pick the one with the best audio quality and speaking-rate stability.
+
 ### Speaker encoder expectations
 
 The guide should warn that a fine-tuned checkpoint may work for preset-speaker synthesis while not supporting the legacy speaker-encoder cloning path in the same way as the stock base checkpoint. Users should validate the exact inference path they intend to use.
+
+### macOS expectations
+
+The guide should describe macOS and Apple Silicon as best-effort for preparation tasks unless explicitly validated. The only behaviors this repo can describe confidently in this pass are GGUF conversion and local inference validation on macOS.
 
 ### Server and C API limitations
 
@@ -104,7 +114,10 @@ Before the documentation work is considered complete:
 - The new guide should be checked for consistency with the upstream fine-tuning README and scripts
 - The README link should land near the existing voice-related sections
 - The commands shown for `qwen3-tts.cpp` should reflect current local behavior, especially explicit `--tts-model` loading
+- The guide should require `--list-speakers` after conversion and confirm that the trained `speaker_name` appears in the preset list
+- The guide should require a synthesis sanity check using `--speaker <name>` after `--list-speakers` succeeds
 - The guide should distinguish supported behavior from best-effort or known-limited behavior
+- The guide should tell users to choose a specific upstream checkpoint before conversion rather than assuming the final epoch is correct
 
 ## Non-Goals
 
@@ -116,6 +129,7 @@ Before the documentation work is considered complete:
 ## Risks
 
 - Upstream fine-tuning scripts may continue to evolve, so commands and assumptions may drift over time
+- Upstream checkpoint quality may drift across epochs, so conversion of the final checkpoint is not always the right default
 - Some users will expect macOS local training; the guide must be explicit that Linux/CUDA is the supported training path
 - Users may assume “fine-tuned custom voices” means the same runtime behavior as the stock CustomVoice releases; the guide should call out where that assumption is unsafe
 
@@ -124,7 +138,8 @@ Before the documentation work is considered complete:
 Proceed with a documentation-only implementation that standardizes:
 
 - upstream `Qwen3-TTS-12Hz-1.7B-Base` fine-tuning
+- upstream checkpoint selection before export
 - local GGUF conversion in `qwen3-tts.cpp`
-- CLI-based validation with explicit model selection
+- CLI-based validation with explicit model selection, `--list-speakers`, and `--speaker <name>`
 
 This gives users the best currently supportable path without overstating what `qwen3-tts.cpp` owns today.

--- a/docs/plans/2026-04-22-fine-tuning-custom-voices.md
+++ b/docs/plans/2026-04-22-fine-tuning-custom-voices.md
@@ -1,0 +1,87 @@
+# Fine-Tuning Custom Voices Guide Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an end-user guide for creating custom fine-tuned voices with upstream Qwen3-TTS training, GGUF conversion, and `qwen3-tts.cpp` validation.
+
+**Architecture:** This is a docs-only change. Add a new operational runbook under `docs/`, then add a short README entry point near the existing CustomVoice section so users can discover the guide and load fine-tuned checkpoints correctly.
+
+**Tech Stack:** Markdown docs, GitHub README, upstream Qwen3-TTS fine-tuning workflow, local `qwen3-tts.cpp` CLI behavior.
+
+---
+
+### Task 1: Add the end-user training guide
+
+**Files:**
+- Create: `docs/fine-tuning-custom-voices.md`
+- Reference: `docs/plans/2026-04-22-fine-tuning-custom-voices-design.md`
+- Reference: `scripts/convert_tts_to_gguf.py`
+- Reference: `src/main.cpp`
+
+- [ ] **Step 1: Draft the guide structure from the approved design**
+
+Write sections for support matrix, environment setup, dataset format, upstream preparation, fine-tuning, checkpoint selection, GGUF conversion, local validation, and troubleshooting.
+
+- [ ] **Step 2: Fill in upstream workflow details from official sources**
+
+Use the current upstream `QwenLM/Qwen3-TTS` fine-tuning README plus `prepare_data.py` and `sft_12hz.py` so the guide matches the official data format and commands.
+
+- [ ] **Step 3: Add repo-specific GGUF conversion guidance**
+
+Document how to convert the chosen fine-tuned checkpoint with `scripts/convert_tts_to_gguf.py`, where to place the output file, and why users should avoid relying on default model auto-detection.
+
+- [ ] **Step 4: Add explicit validation steps**
+
+Require:
+- `--list-speakers`
+- confirmation that the trained `speaker_name` appears
+- a synthesis sanity check with `--speaker <name>`
+
+- [ ] **Step 5: Add limitations and troubleshooting**
+
+Call out:
+- Linux/CUDA as the supported training path
+- macOS as best-effort for conversion and local inference validation
+- `0.6B` out of scope
+- checkpoint quality drift across epochs
+- server/C API model-selection limitations
+
+### Task 2: Add README discoverability
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Add a short subsection near CustomVoice / VoiceDesign**
+
+Link to `docs/fine-tuning-custom-voices.md` and explain that fine-tuned checkpoints should be loaded with `--tts-model <file>`.
+
+- [ ] **Step 2: Keep claims aligned with actual repo behavior**
+
+Do not imply that the server or C API automatically support arbitrary fine-tuned checkpoint names.
+
+### Task 3: Verify the docs
+
+**Files:**
+- Verify: `docs/fine-tuning-custom-voices.md`
+- Verify: `README.md`
+
+- [ ] **Step 1: Re-read the new guide against upstream commands**
+
+Check that JSONL fields, `prepare_data.py`, and `sft_12hz.py` arguments match current upstream behavior.
+
+- [ ] **Step 2: Re-read the local validation steps against `qwen3-tts.cpp`**
+
+Check that the CLI validation flow reflects the current repo:
+- `--tts-model <file>`
+- `--list-speakers`
+- `--speaker <name>`
+
+- [ ] **Step 3: Check the final diff**
+
+Run:
+
+```bash
+git diff -- docs/fine-tuning-custom-voices.md README.md docs/plans/2026-04-22-fine-tuning-custom-voices.md
+```
+
+Expected: only the new guide, the README link, and this plan file are changed.

--- a/docs/superpowers/plans/2026-06-18-cross-platform-qwen3-tts-performance.md
+++ b/docs/superpowers/plans/2026-06-18-cross-platform-qwen3-tts-performance.md
@@ -1,0 +1,696 @@
+# Cross-Platform Qwen3-TTS Performance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add benchmark visibility and low-risk cross-platform speedups for `qwen3-tts.cpp`, then gate deeper GGML scheduler and server-cache optimizations on measured wins.
+
+**Architecture:** Keep public synthesis semantics unchanged. Add structured benchmark output at the CLI/result boundary, fix backend thread propagation through existing runtime boundaries, pilot GGML scheduler reservation behind an opt-in flag, and add explicit ICL prompt caching through a small core/C API/server path.
+
+**Tech Stack:** C++17, GGML scheduler/backends, CMake/CTest, Python `ctypes` server binding, FastAPI server.
+
+---
+
+## Scope Notes
+
+The design covers four related but independently shippable slices. Implement them in order and commit after each task. If Task 1 shows graph build/allocation is not material on the target backend, skip Task 3 and record that result in the docs instead of forcing a scheduler abstraction.
+
+The current repo has unrelated dirty worktree changes. Start implementation in a dedicated worktree from the current committed design head and do not revert unrelated edits in the original checkout.
+
+## File Structure
+
+- `src/common/benchmark_json.h` / `src/common/benchmark_json.cpp`: small JSON writer for benchmark records; no dependency on a third-party JSON library.
+- `tests/test_benchmark_json.cpp`: unit tests for JSON escaping and computed timing fields.
+- `src/transformer/tts_transformer.h` / `src/transformer/tts_transformer.cpp`: expose last detailed generation timing under `QWEN3_TTS_TIMING`; optionally hold scheduler reservation state.
+- `src/pipeline/qwen3_tts.h` / `src/pipeline/qwen3_tts.cpp`: carry detailed timing into `tts_result`, add thread setter, and add prepared ICL prompt APIs.
+- `src/common/backend_threads.h` / `src/common/backend_threads.cpp`: backend-thread helper for CPU and backend registry thread hooks.
+- `src/common/gguf_loader.cpp`: apply default backend thread count when shared preferred backends are created.
+- `src/pipeline/qwen3tts_c_api.h` / `src/pipeline/qwen3tts_c_api.cpp`: expose effective thread behavior and opaque prepared ICL prompt handles.
+- `server/qwen3_tts_binding.py`: bind prepared ICL prompt APIs and pass thread settings consistently.
+- `server/icl_cache.py`: deterministic ICL prompt cache key and bounded cache.
+- `server/main.py`: use `server/icl_cache.py` for repeated ICL requests.
+- `tests/test_backend_threads.cpp`: focused helper test for CPU backend thread application.
+- `server/tests/test_icl_cache.py`: pure-Python tests for cache key, hit/miss, and invalidation behavior.
+- `CMakeLists.txt`: add the new common sources and test targets.
+- `README.md` and `server/README.md`: document benchmark JSON, thread behavior, graph reservation flag, and ICL cache scope.
+
+## Task 0: Isolate Implementation Worktree
+
+**Files:**
+- No repo file changes.
+
+- [ ] **Step 1: Create a dedicated worktree**
+
+Run:
+
+```bash
+git worktree add ../qwen3-tts.cpp-perf-cross-platform HEAD -b perf/cross-platform-qwen3-tts
+```
+
+Expected: new worktree created from the current committed spec head.
+
+- [ ] **Step 2: Check the implementation worktree status**
+
+Run:
+
+```bash
+git -C ../qwen3-tts.cpp-perf-cross-platform status --short
+```
+
+Expected: no unrelated modified files. If dirty, stop and inspect before editing.
+
+- [ ] **Step 3: Configure a timing build**
+
+Run:
+
+```bash
+cmake -S . -B build-perf -DQWEN3_TTS_TIMING=ON
+cmake --build build-perf -j
+```
+
+Expected: build completes. If model-dependent tests are not runnable locally, continue with non-model unit tests and document the blocker.
+
+## Task 1: Add Structured Benchmark Output
+
+**Files:**
+- Create: `src/common/benchmark_json.h`
+- Create: `src/common/benchmark_json.cpp`
+- Create: `tests/test_benchmark_json.cpp`
+- Modify: `CMakeLists.txt`
+- Modify: `src/transformer/tts_transformer.h`
+- Modify: `src/transformer/tts_transformer.cpp`
+- Modify: `src/pipeline/qwen3_tts.h`
+- Modify: `src/pipeline/qwen3_tts.cpp`
+- Modify: `src/main.cpp`
+
+- [ ] **Step 1: Write failing JSON helper tests**
+
+Add `tests/test_benchmark_json.cpp` with tests like:
+
+```cpp
+#include "common/benchmark_json.h"
+
+#include <cassert>
+#include <string>
+
+int main() {
+    qwen3_tts::benchmark_record r;
+    r.mode = "default";
+    r.backend = "cpu";
+    r.text = "hello \"tts\"";
+    r.audio_seconds = 2.0;
+    r.total_ms = 1000;
+    r.generate_ms = 700;
+
+    const std::string json = qwen3_tts::benchmark_record_to_json(r);
+    assert(json.find("\"mode\":\"default\"") != std::string::npos);
+    assert(json.find("hello \\\"tts\\\"") != std::string::npos);
+    assert(json.find("\"speed_x_realtime\":2") != std::string::npos);
+    assert(json.find("\"wall_rtf\":0.5") != std::string::npos);
+    return 0;
+}
+```
+
+- [ ] **Step 2: Register the failing test**
+
+Add `src/common/benchmark_json.cpp` to `COMMON_SOURCES`, add a `test_benchmark_json` executable, and add a `benchmark_json_test` CTest entry.
+
+Run:
+
+```bash
+cmake --build build-perf -j
+ctest --test-dir build-perf -R benchmark_json_test --output-on-failure
+```
+
+Expected: build or test fails because `benchmark_json` does not exist yet.
+
+- [ ] **Step 3: Implement the JSON helper**
+
+Create `benchmark_record` with fields for mode, backend, device, thread count, model type, model size, quantization/model names, text, audio seconds, total/tokenize/encode/generate/decode ms, memory snapshots, and optional detailed timing values.
+
+Keep it dependency-free:
+
+```cpp
+namespace qwen3_tts {
+struct benchmark_record {
+    std::string mode;
+    std::string backend;
+    std::string device;
+    int32_t thread_count = 0;
+    std::string model_type;
+    std::string model_size;
+    std::string text;
+    double audio_seconds = 0.0;
+    int64_t tokenize_ms = 0;
+    int64_t encode_ms = 0;
+    int64_t generate_ms = 0;
+    int64_t decode_ms = 0;
+    int64_t total_ms = 0;
+};
+
+std::string benchmark_record_to_json(const benchmark_record & r);
+bool write_benchmark_record_json(const std::string & path, const benchmark_record & r, std::string & error);
+}
+```
+
+Computed fields:
+
+- `speed_x_realtime = audio_seconds / (total_ms / 1000.0)`
+- `wall_rtf = (total_ms / 1000.0) / audio_seconds`
+
+- [ ] **Step 4: Expose detailed transformer timing to results**
+
+Under `QWEN3_TTS_TIMING`, add a copy of the last `tts_timing` to `TTSTransformer` and `tts_result`.
+
+Sketch:
+
+```cpp
+#ifdef QWEN3_TTS_TIMING
+const tts_timing * TTSTransformer::last_timing() const {
+    return has_last_timing_ ? &last_timing_ : nullptr;
+}
+#endif
+```
+
+At the end of `TTSTransformer::generate`, store the local timing struct before clearing `timing_`. In `Qwen3TTS::synthesize_internal`, copy it to `result` after `transformer_.generate(...)` succeeds.
+
+- [ ] **Step 5: Add CLI flags**
+
+Add to `src/main.cpp`:
+
+- `--benchmark-json <file>`
+- `--quiet-progress` or reuse an existing setting to disable progress output for benchmark runs
+
+After synthesis succeeds, populate a `benchmark_record` and write it if `--benchmark-json` is set. Include the mode selected by CLI path:
+
+- `default`
+- `speaker_embedding`
+- `preset`
+- `xvector_voice_clone`
+- `icl_voice_clone`
+
+- [ ] **Step 6: Verify helper tests pass**
+
+Run:
+
+```bash
+cmake --build build-perf -j
+ctest --test-dir build-perf -R benchmark_json_test --output-on-failure
+```
+
+Expected: `benchmark_json_test` passes.
+
+- [ ] **Step 7: Smoke benchmark JSON with a local model if available**
+
+Run:
+
+```bash
+./build-perf/qwen3-tts-cli -m models \
+  -t "Benchmark smoke test." \
+  --seed 1234 --max-tokens 32 \
+  --benchmark-json /tmp/qwen3-tts-bench.json \
+  -o /tmp/qwen3-tts-bench.wav
+```
+
+Expected: JSON file exists and includes timing, audio duration, `speed_x_realtime`, and `wall_rtf`. If local models are missing, record the blocker and rely on unit tests.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add CMakeLists.txt src/common/benchmark_json.* tests/test_benchmark_json.cpp \
+  src/transformer/tts_transformer.* src/pipeline/qwen3_tts.* src/main.cpp
+git commit -m "feat: add structured benchmark output"
+```
+
+## Task 2: Wire Effective Backend Thread Controls
+
+**Files:**
+- Create: `src/common/backend_threads.h`
+- Create: `src/common/backend_threads.cpp`
+- Create: `tests/test_backend_threads.cpp`
+- Modify: `CMakeLists.txt`
+- Modify: `src/common/gguf_loader.h`
+- Modify: `src/common/gguf_loader.cpp`
+- Modify: `src/pipeline/qwen3_tts.h`
+- Modify: `src/pipeline/qwen3_tts.cpp`
+- Modify: `src/pipeline/qwen3tts_c_api.cpp`
+- Modify: `server/qwen3_tts_binding.py`
+
+- [ ] **Step 1: Write failing backend-thread helper test**
+
+Add `tests/test_backend_threads.cpp`:
+
+```cpp
+#include "common/backend_threads.h"
+#include "ggml-backend.h"
+
+#include <cassert>
+
+int main() {
+    ggml_backend_t cpu = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, nullptr);
+    assert(cpu != nullptr);
+    assert(qwen3_tts::apply_backend_n_threads(cpu, 1));
+    assert(qwen3_tts::apply_backend_n_threads(cpu, 2));
+    assert(!qwen3_tts::apply_backend_n_threads(nullptr, 2));
+    assert(!qwen3_tts::apply_backend_n_threads(cpu, 0));
+    ggml_backend_free(cpu);
+    return 0;
+}
+```
+
+Register `test_backend_threads` in `CMakeLists.txt`.
+
+Run:
+
+```bash
+cmake --build build-perf -j
+ctest --test-dir build-perf -R backend_threads_test --output-on-failure
+```
+
+Expected: fails because helper does not exist.
+
+- [ ] **Step 2: Implement `backend_threads` helper**
+
+Use GGML backend registry support when available, and include CPU fallback support:
+
+```cpp
+bool apply_backend_n_threads(ggml_backend_t backend, int32_t n_threads);
+void set_default_backend_n_threads(int32_t n_threads);
+int32_t get_default_backend_n_threads();
+```
+
+Implementation should:
+
+- reject `nullptr` and `n_threads <= 0`
+- look up `ggml_backend_set_n_threads` through the backend registry
+- fall back to `ggml_backend_cpu_set_n_threads` for CPU backends
+- return `false` for backends with no thread hook, without treating that as fatal
+
+- [ ] **Step 3: Apply default threads at backend creation**
+
+In `init_preferred_backend(...)`, after backend creation and before storing the shared backend, call `apply_backend_n_threads(backend, get_default_backend_n_threads())`.
+
+Also apply thread count to CPU fallback backends created directly in model components, especially `TTSTransformer::load_model`.
+
+- [ ] **Step 4: Add runtime setter on `Qwen3TTS`**
+
+Add:
+
+```cpp
+void Qwen3TTS::set_n_threads(int32_t n_threads);
+```
+
+It should update the default backend thread count and apply it to loaded component backends where accessible. Keep unsupported GPU backends non-fatal.
+
+- [ ] **Step 5: Wire C API constructor and per-call params**
+
+In `qwen3_tts_create_with_models(...)`, replace `(void)n_threads` with:
+
+```cpp
+if (n_threads > 0) {
+    tts->engine.set_n_threads(n_threads);
+}
+```
+
+Before synthesis calls, apply `cpp_params.n_threads` through `engine.set_n_threads(...)` so CLI and server per-request params are effective.
+
+- [ ] **Step 6: Verify tests**
+
+Run:
+
+```bash
+cmake --build build-perf -j
+ctest --test-dir build-perf -R "backend_threads_test|benchmark_json_test|sampling_test" --output-on-failure
+```
+
+Expected: listed tests pass.
+
+- [ ] **Step 7: Smoke CPU benchmark thread variation if models are available**
+
+Run:
+
+```bash
+QWEN3_TTS_BACKEND=cpu ./build-perf/qwen3-tts-cli -m models \
+  -t "Thread benchmark." --seed 1234 --max-tokens 32 -j 1 \
+  --benchmark-json /tmp/qwen3-tts-j1.json -o /tmp/qwen3-tts-j1.wav
+
+QWEN3_TTS_BACKEND=cpu ./build-perf/qwen3-tts-cli -m models \
+  -t "Thread benchmark." --seed 1234 --max-tokens 32 -j 4 \
+  --benchmark-json /tmp/qwen3-tts-j4.json -o /tmp/qwen3-tts-j4.wav
+```
+
+Expected: both runs complete. The JSON records should show `thread_count` as 1 and 4 respectively. Record observed `generate_ms`, `total_ms`, and whether the CPU backend thread hook was applied. Do not require a fixed speedup threshold, but if timing does not change or the hook cannot be applied, document that result explicitly instead of claiming a speedup.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add CMakeLists.txt src/common/backend_threads.* src/common/gguf_loader.* \
+  src/pipeline/qwen3_tts.* src/pipeline/qwen3tts_c_api.cpp \
+  server/qwen3_tts_binding.py tests/test_backend_threads.cpp
+git commit -m "fix: apply qwen3 tts thread settings"
+```
+
+## Task 3: Pilot GGML Scheduler Reservation for Code Predictor
+
+**Files:**
+- Modify: `src/transformer/tts_transformer.h`
+- Modify: `src/transformer/tts_transformer.cpp`
+- Modify: `src/common/benchmark_json.h`
+- Modify: `src/common/benchmark_json.cpp`
+- Modify: `README.md`
+
+- [ ] **Step 1: Add reservation metrics behind timing**
+
+Extend `tts_timing` with:
+
+```cpp
+double t_code_pred_reserve_ms = 0;
+int32_t n_code_pred_reserve_attempts = 0;
+int32_t n_code_pred_reserve_successes = 0;
+```
+
+Add the same fields to `benchmark_record`.
+
+- [ ] **Step 2: Add opt-in reservation flag**
+
+Add an internal helper:
+
+```cpp
+bool TTSTransformer::graph_reservation_enabled() const;
+```
+
+Read `QWEN3_TTS_GRAPH_RESERVE=1`. Default must be off for the first implementation pass.
+
+- [ ] **Step 3: Implement the smallest code-predictor reservation pilot**
+
+Add state for whether the code-predictor reservation has been attempted for the currently loaded model/backend.
+
+Pilot logic:
+
+1. On first `predict_codes_autoregressive(...)`, build a representative prefill graph.
+2. Call `ggml_backend_sched_reserve(state_.sched, prefill_graph)`.
+3. Build a representative maximum step graph using `n_past = 15` and `generation_step = 14`.
+4. Call `ggml_backend_sched_reserve(state_.sched, step_graph)`.
+5. Do not cache raw `ggml_cgraph *` beyond the call.
+6. If either reservation fails, disable reservation for the session and continue normal inference.
+
+- [ ] **Step 4: Preserve normal compute behavior**
+
+Keep the existing per-step `build_code_pred_*`, `ggml_backend_sched_alloc_graph`, tensor set/get, compute, sample, and reset sequence. This task is only about avoiding repeated backend buffer planning if GGML can use the reservation.
+
+- [ ] **Step 5: Verify compile and core tests**
+
+Run:
+
+```bash
+cmake --build build-perf -j
+ctest --test-dir build-perf -R "transformer_test|sampling_test|benchmark_json_test" --output-on-failure
+```
+
+Expected: tests pass or model-dependent tests report known missing-model blockers. No regression in model-free tests.
+
+- [ ] **Step 6: Benchmark with and without reservation if models are available**
+
+Run:
+
+```bash
+./build-perf/qwen3-tts-cli -m models \
+  -t "Graph reservation benchmark." --seed 1234 --max-tokens 64 \
+  --benchmark-json /tmp/qwen3-tts-no-reserve.json -o /tmp/qwen3-tts-no-reserve.wav
+
+QWEN3_TTS_GRAPH_RESERVE=1 ./build-perf/qwen3-tts-cli -m models \
+  -t "Graph reservation benchmark." --seed 1234 --max-tokens 64 \
+  --benchmark-json /tmp/qwen3-tts-reserve.json -o /tmp/qwen3-tts-reserve.wav
+```
+
+Expected: both runs complete. Compare code-predictor graph allocation time and total generation time. If reservation does not help or causes backend issues, leave it documented as experimental/off and do not enable by default.
+
+- [ ] **Step 7: Verify deterministic output parity**
+
+Run the same prompt, backend, seed, and max-token settings with reservation disabled and enabled:
+
+```bash
+./build-perf/qwen3-tts-cli -m models \
+  -t "Graph reservation parity." --seed 1234 --max-tokens 64 \
+  --benchmark-json /tmp/qwen3-tts-parity-off.json -o /tmp/qwen3-tts-parity-off.wav
+
+QWEN3_TTS_GRAPH_RESERVE=1 ./build-perf/qwen3-tts-cli -m models \
+  -t "Graph reservation parity." --seed 1234 --max-tokens 64 \
+  --benchmark-json /tmp/qwen3-tts-parity-on.json -o /tmp/qwen3-tts-parity-on.wav
+
+shasum -a 256 /tmp/qwen3-tts-parity-off.wav /tmp/qwen3-tts-parity-on.wav
+```
+
+Expected: exact generated-code parity if an accessible code fixture exists. If only WAV output is available, the WAV hashes should match for this reservation-only change. If local models are unavailable, document the model-fixture blocker and do not claim semantic parity.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/transformer/tts_transformer.* src/common/benchmark_json.* README.md
+git commit -m "perf: pilot code predictor scheduler reservation"
+```
+
+## Task 4: Add Prepared ICL Prompt Cache for Server Reuse
+
+**Files:**
+- Create: `server/icl_cache.py`
+- Create: `server/tests/test_icl_cache.py`
+- Modify: `src/pipeline/qwen3_tts.h`
+- Modify: `src/pipeline/qwen3_tts.cpp`
+- Modify: `src/pipeline/qwen3tts_c_api.h`
+- Modify: `src/pipeline/qwen3tts_c_api.cpp`
+- Modify: `server/qwen3_tts_binding.py`
+- Modify: `server/main.py`
+- Modify: `server/README.md`
+- Modify: `CMakeLists.txt` if adding Python cache tests to CTest
+
+- [ ] **Step 1: Add pure Python cache-key tests**
+
+Create `server/tests/test_icl_cache.py` using only the standard library. Test:
+
+- same path/text/model metadata gives same key
+- changed model identity changes key
+- changed reference text changes key
+- changed file mtime/size changes key
+- LRU evicts oldest entry when max size is exceeded
+- evicted values are explicitly closed/freed
+
+Run:
+
+```bash
+python3 server/tests/test_icl_cache.py
+```
+
+Expected: fails because `server/icl_cache.py` does not exist.
+
+- [ ] **Step 2: Implement `server/icl_cache.py`**
+
+Provide:
+
+```python
+@dataclass(frozen=True)
+class IclPromptCacheKey:
+    tts_model_path: str
+    tts_model_size: int
+    tts_model_mtime_ns: int
+    speaker_encoder_model_path: str
+    speaker_encoder_model_size: int
+    speaker_encoder_model_mtime_ns: int
+    codec_encoder_model_path: str
+    codec_encoder_model_size: int
+    codec_encoder_model_mtime_ns: int
+    tokenizer_decoder_model_path: str
+    tokenizer_decoder_model_size: int
+    tokenizer_decoder_model_mtime_ns: int
+    reference_path: str
+    reference_size: int
+    reference_mtime_ns: int
+    reference_text_hash: str
+    language_id: int
+
+class IclPromptCache:
+    def __init__(self, max_entries: int): ...
+    def get(self, key): ...
+    def put(self, key, value): ...
+    def clear(self): ...
+```
+
+Use `OrderedDict` for LRU behavior. Include every model component that can affect prepared ICL output. In the current runtime the TTS model path may also contain speaker-encoder tensors, and the tokenizer/vocoder model path may also contain the Mimi codec encoder, but the cache key should name those roles explicitly even when their resolved paths are identical. Cache values must own prompt handles deterministically: when an entry is evicted or the cache is cleared, call `close()` on the cached value so the underlying `qwen3_tts_free_icl_prompt(...)` runs. Do not rely only on Python finalizers.
+
+- [ ] **Step 3: Add C++ prepared prompt model**
+
+In `src/pipeline/qwen3_tts.h`, add:
+
+```cpp
+struct icl_prompt {
+    std::vector<float> speaker_embedding;
+    std::vector<int32_t> ref_codes;
+    int32_t n_ref_frames = 0;
+    std::string ref_text;
+};
+
+bool prepare_icl_prompt(const std::string & reference_audio,
+                        const std::string & reference_text,
+                        const tts_params & params,
+                        icl_prompt & out);
+
+tts_result synthesize_with_icl_prompt(const std::string & text,
+                                      const icl_prompt & prompt,
+                                      const tts_params & params = tts_params());
+```
+
+Move the existing reference load/resample, speaker-encoder, and codec-encoder work from `synthesize_with_voice(...)` into `prepare_icl_prompt(...)`. Keep `synthesize_with_voice(...)` behavior unchanged by having it prepare and immediately use a prompt.
+
+- [ ] **Step 4: Expose opaque C API prompt handles**
+
+Add to `qwen3tts_c_api.h`:
+
+```c
+typedef struct Qwen3TtsIclPrompt Qwen3TtsIclPrompt;
+
+Qwen3TtsIclPrompt* qwen3_tts_prepare_icl_prompt_file(
+    Qwen3Tts* tts,
+    const char* reference_audio_path,
+    const char* reference_text,
+    const Qwen3TtsParams* params);
+
+Qwen3TtsAudio* qwen3_tts_synthesize_with_icl_prompt(
+    Qwen3Tts* tts,
+    const char* text,
+    const Qwen3TtsIclPrompt* prompt,
+    const Qwen3TtsParams* params);
+
+void qwen3_tts_free_icl_prompt(Qwen3TtsIclPrompt* prompt);
+```
+
+Implement ownership with a heap-allocated wrapper around `qwen3_tts::icl_prompt`.
+
+- [ ] **Step 5: Bind prompt handles in Python**
+
+In `server/qwen3_tts_binding.py`, add:
+
+- `prepare_icl_prompt(reference_audio_path, reference_text, ...)`
+- `synthesize_with_icl_prompt(text, prompt_handle, ...)`
+- prompt handle finalizer that calls `qwen3_tts_free_icl_prompt`
+- resolved model identity fields for cache keys: TTS model, speaker-encoder model, codec-encoder model, and tokenizer/vocoder decoder model path/size/mtime. These role identities may point to the same underlying GGUF file, but the binding should expose them separately so future split-model layouts do not produce stale cache hits.
+
+Keep raw pointer handling private to the binding.
+
+- [ ] **Step 6: Use cache in server ICL route**
+
+In `server/main.py`, add:
+
+- `QWEN3TTS_ICL_CACHE_SIZE` env var, default `8`
+- global `icl_prompt_cache`
+- cache key from `server/icl_cache.py`
+
+Inside the existing `_synthesis_lock`, get or prepare the prompt, then call `synthesize_with_icl_prompt(...)`.
+
+Do not add parallel request execution. The cache reduces repeated preprocessing only.
+
+On FastAPI lifespan shutdown, clear the ICL cache before destroying `tts_engine` so cached C prompt handles are freed while the library and engine are still valid.
+
+- [ ] **Step 7: Verify tests**
+
+Run:
+
+```bash
+python3 server/tests/test_icl_cache.py
+cmake --build build-perf -j
+ctest --test-dir build-perf -R "c_api_customvoice_test|benchmark_json_test|backend_threads_test" --output-on-failure
+```
+
+Expected: Python cache tests pass. C/C++ tests pass or model-dependent tests report known blockers.
+
+- [ ] **Step 8: Smoke repeated ICL if models and reference audio are available**
+
+Run two identical `/v1/audio/speech` ICL requests and log whether the second request reports an ICL cache hit. If local server dependencies or models are unavailable, document the blocker.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/pipeline/qwen3_tts.* src/pipeline/qwen3tts_c_api.* \
+  server/qwen3_tts_binding.py server/main.py server/icl_cache.py \
+  server/tests/test_icl_cache.py server/README.md CMakeLists.txt
+git commit -m "perf: cache prepared icl prompts in server"
+```
+
+## Task 5: Documentation and Final Verification
+
+**Files:**
+- Modify: `README.md`
+- Modify: `server/README.md`
+- Modify: `docs/superpowers/specs/2026-05-04-cross-platform-qwen3-tts-performance-design.md` only if implementation findings change the design assumptions.
+
+- [ ] **Step 1: Document benchmark usage**
+
+Add a short README section with:
+
+```bash
+cmake -S . -B build-perf -DQWEN3_TTS_TIMING=ON
+cmake --build build-perf -j
+./build-perf/qwen3-tts-cli -m models -t "Benchmark." \
+  --seed 1234 --max-tokens 64 \
+  --benchmark-json bench.json -o bench.wav
+```
+
+Explain `speed_x_realtime` and `wall_rtf`.
+
+- [ ] **Step 2: Document thread behavior**
+
+Clarify that `-j/--threads`, C API `n_threads`, and `QWEN3TTS_THREADS` affect CPU-capable backends when GGML exposes a thread hook. GPU-only backends may ignore it.
+
+- [ ] **Step 3: Document scheduler reservation**
+
+If Task 3 remains opt-in, document:
+
+```bash
+QWEN3_TTS_GRAPH_RESERVE=1 ./build-perf/qwen3-tts-cli ...
+```
+
+Clearly mark it experimental unless measurements justify enabling by default.
+
+- [ ] **Step 4: Document ICL cache**
+
+In `server/README.md`, document:
+
+- `QWEN3TTS_ICL_CACHE_SIZE`
+- what is cached
+- that JSON speaker embeddings were already cached separately
+- that the server still uses the synthesis lock
+
+- [ ] **Step 5: Full verification sweep**
+
+Run:
+
+```bash
+git diff --check
+cmake --build build-perf -j
+ctest --test-dir build-perf --output-on-failure
+python3 server/tests/test_icl_cache.py
+```
+
+Expected:
+
+- no whitespace errors
+- build succeeds
+- model-free tests pass
+- model-dependent failures are either fixed or explicitly documented as missing local model/reference fixtures
+
+- [ ] **Step 6: Final benchmark capture if models are available**
+
+Capture before/after JSON records from the same command, same seed, same backend, and same `--max-tokens`. Save the numbers in the final implementation summary; do not commit generated WAV/JSON files unless the user asks.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add README.md server/README.md docs/superpowers/specs/2026-05-04-cross-platform-qwen3-tts-performance-design.md
+git commit -m "docs: document qwen3 tts performance controls"
+```
+
+## Execution Notes
+
+- Prefer Task 1 and Task 2 as the first implementation PR. They are low-risk and make the rest measurable.
+- Treat Task 3 as conditional. If graph allocation is not visible in benchmark output, skip it.
+- Treat Task 4 as a separate PR if Task 1/2 are already useful; it expands API surface and deserves focused review.
+- Do not enable CUDA-only graph capture in this plan.
+- Do not change sampling behavior to make graph fusion easier.

--- a/docs/superpowers/specs/2026-05-04-cross-platform-qwen3-tts-performance-design.md
+++ b/docs/superpowers/specs/2026-05-04-cross-platform-qwen3-tts-performance-design.md
@@ -1,0 +1,169 @@
+# Cross-Platform Qwen3-TTS Performance Design
+
+## Goal
+
+Adapt the useful performance lessons from `andimarafioti/faster-qwen3-tts` into `qwen3-tts.cpp` without making the first optimization pass NVIDIA-only.
+
+The first implementation track should improve or validate speedups that can help GGML CPU, Metal, Vulkan, CUDA, and other scheduler-backed backends. CUDA graph capture can remain a later backend-specific track after the cross-platform hot paths are measured and cleaned up.
+
+## Context
+
+`faster-qwen3-tts` gets its major speedups from CUDA graph capture, static KV cache buffers, pre-allocated tensors, and fixed-shape padded attention. Its README reports large RTF and TTFA improvements on CUDA systems and explains that Qwen3-TTS spends substantial time launching many small kernels per decode step.
+
+That exact implementation depends on PyTorch CUDA graph APIs and NVIDIA CUDA behavior. It is not directly portable to a GGML C++ runtime, and it does not help macOS Metal, Vulkan, or CPU users.
+
+The reusable lesson is still relevant: avoid dynamic work inside the per-frame decode loop. In this repository, the local transformer path currently rebuilds, allocates, computes, and resets GGML graphs in hot paths, including the talker step and the code predictor prefill plus 14 autoregressive predictor steps per audio frame.
+
+## Target
+
+Optimize for cross-platform local inference first:
+
+- CPU users should benefit from correctly wired thread settings and lower scheduler overhead.
+- Metal, Vulkan, CUDA, and other GGML backends should benefit from less graph lifecycle churn where graph shape allows it.
+- Server users should benefit from reuse of speaker and reference prompt work across repeated requests.
+
+## Non-Goals
+
+- Do not start by porting PyTorch `torch.cuda.CUDAGraph`.
+- Do not make CUDA the only fast path in the first pass.
+- Do not redesign model weights, GGUF conversion, or public inference semantics.
+- Do not accept quality regressions or token-shape changes without parity tests.
+- Do not treat streaming as a throughput fix by itself. Streaming can reduce time-to-first-audio, but total RTF still depends on the same decode hot path.
+
+## Proposed Phases
+
+### Phase 1: Baseline and Profiling
+
+Create a repeatable benchmark path before changing the runtime. The benchmark should record:
+
+- total synthesis wall time
+- generated audio duration and RTF
+- TTFA where streaming is available
+- talker graph build, allocation, data transfer, and compute time
+- code predictor graph build, allocation, data transfer, and compute time
+- backend, quantization, thread count, model size, prompt length, and max token settings
+
+The existing timing counters in `TTSTimingStats` already expose much of this information. The implementation plan should first determine whether those counters are sufficient or whether a small benchmark wrapper is needed.
+
+Success criteria:
+
+- One documented CPU benchmark command.
+- One documented accelerator benchmark command when a backend is available.
+- Timing output that can show whether graph lifecycle overhead is material.
+
+### Phase 2: Runtime Knob Cleanup
+
+Fix low-risk runtime controls before attempting deeper graph changes.
+
+The C API exposes `n_threads`, and the CLI/server pass thread values, but the current create path ignores the constructor argument and comments that threads are set per call. The implementation should trace whether per-call thread count is actually applied to the GGML CPU backend. If not, wire it through deliberately.
+
+The server should expose the same effective knobs as the CLI where practical:
+
+- backend selection
+- thread count
+- max audio tokens
+- quantization/model selection guidance
+- timing/profiling mode when compiled with timing enabled
+
+Success criteria:
+
+- CPU thread count has a verified effect or is clearly documented as unsupported.
+- CLI and server behavior are consistent enough that benchmark results are comparable.
+- Documentation describes practical speed knobs without overstating platform-specific features.
+
+### Phase 3: GGML Graph Lifecycle Optimization
+
+Use the benchmark data to reduce repeated scheduler work in the hottest safe path.
+
+Start with the code predictor. It runs once per generated frame and includes one prefill graph followed by 14 step graphs. This makes it the best candidate for reusable graph reservations or a small cache of stable graph variants.
+
+The implementation should investigate these options in order:
+
+1. Reserve scheduler memory with a max-shape graph where GGML supports it.
+2. Reuse graph allocation for stable-shape predictor graphs.
+3. Keep input tensors in dedicated contexts where GGML allows static allocation.
+4. Only then consider larger structural changes such as unrolling the predictor sequence into fewer graph executions.
+
+Apply the same pattern to the talker step only if profiling shows graph build or allocation time is meaningful there.
+
+Success criteria:
+
+- The graph optimization is guarded by tests or benchmarks that detect regressions.
+- Generated output remains compatible with the existing sampling and token generation behavior.
+- Backends that cannot benefit still run correctly.
+
+### Phase 4: Server Reuse
+
+Add server-side reuse for work that does not need to be repeated on every request.
+
+Useful reuse candidates:
+
+- speaker embeddings
+- reference audio codec tokens
+- reference text tokenization
+- prompt structures for repeated voice clone or CustomVoice requests
+
+This phase should not change the core transformer math. It should reduce repeated setup latency in server mode and make repeated requests more comparable to the warm-cache behavior described by `faster-qwen3-tts`.
+
+Success criteria:
+
+- Repeated requests for the same voice avoid redundant prompt/reference preprocessing.
+- Cache keys include all inputs that affect output correctness.
+- Cache size and invalidation behavior are explicit.
+
+### Phase 5: Static-Shape Decode Feasibility
+
+After phases 1-4, decide whether to attempt the deeper adaptation of the faster repo's static-cache idea.
+
+This would mean building a fixed-shape decode path with static KV/cache buffers and explicit masks so that graph structure remains stable while logical sequence length changes. It is the closest cross-platform analog to the faster repo's static cache plus CUDA graph capture design, but it is also the riskiest part.
+
+This phase should start as a feasibility branch, not as an immediate production change.
+
+Success criteria:
+
+- Clear proof that dynamic graph shape is a limiting factor after easier fixes.
+- Prefix-parity or perceptual-quality tests for generated codec tokens/audio.
+- Backend-specific fallbacks for unsupported cases.
+
+## Architecture
+
+The design should keep optimization logic close to existing runtime boundaries:
+
+- `TTSTransformer` owns graph construction, KV cache state, timing counters, and scheduler interaction.
+- The C API and server own user-facing params and should not know graph-cache internals.
+- Benchmark/documentation helpers should consume public CLI/server interfaces where possible.
+
+If a reusable graph cache is introduced, it should be a small internal helper with explicit ownership:
+
+- keyed by graph role, step index, shape, backend-relevant dimensions, and model config
+- invalidated when context size, backend, or model changes
+- hidden from public API consumers
+
+## Testing
+
+The implementation plan should include focused tests at three levels:
+
+- Unit or integration tests for thread-param propagation and cache key behavior.
+- Existing transformer tests to catch generation regressions.
+- Benchmark comparisons before and after graph lifecycle changes.
+
+Performance tests should report numbers but should not be brittle pass/fail checks unless a stable local fixture already exists.
+
+## Risks
+
+- GGML graph tensors are not always reusable in the same way across backends.
+- `n_past` changes graph shape in the current talker path, which may limit reuse.
+- Static-shape attention masking could change numerical behavior even if the algorithm is equivalent.
+- Server caches can return wrong results if cache keys omit reference audio, reference text, language, speaker, or model identity.
+- Existing worktree changes are present, so implementation should keep future edits narrowly staged.
+
+## Recommendation
+
+Proceed with phases 1-4 as the first implementation plan:
+
+1. make performance measurement reproducible
+2. fix easy runtime knobs
+3. optimize GGML graph lifecycle where profiling proves overhead
+4. add safe server-side reuse for repeated prompt/reference work
+
+Treat full static-shape decode as a later feasibility project. It is likely the closest conceptual match to `faster-qwen3-tts`, but it should be justified by measurements after the lower-risk cross-platform work is complete.

--- a/docs/superpowers/specs/2026-05-04-cross-platform-qwen3-tts-performance-design.md
+++ b/docs/superpowers/specs/2026-05-04-cross-platform-qwen3-tts-performance-design.md
@@ -14,6 +14,8 @@ That exact implementation depends on PyTorch CUDA graph APIs and NVIDIA CUDA beh
 
 The reusable lesson is still relevant: avoid dynamic work inside the per-frame decode loop. In this repository, the local transformer path currently rebuilds, allocates, computes, and resets GGML graphs in hot paths, including the talker step and the code predictor prefill plus 14 autoregressive predictor steps per audio frame.
 
+The faster repo also puts useful boundaries around correctness: its fast path is allowed to differ numerically from dynamic-cache upstream execution, but it keeps explicit parity tests and distinguishes fast-path streaming from slower validation-only dynamic-cache streaming. This repository should copy that discipline even when the implementation mechanism is different.
+
 ## Target
 
 Optimize for cross-platform local inference first:
@@ -42,6 +44,8 @@ Create a repeatable benchmark path before changing the runtime. The benchmark sh
 - talker graph build, allocation, data transfer, and compute time
 - code predictor graph build, allocation, data transfer, and compute time
 - backend, quantization, thread count, model size, prompt length, and max token settings
+- generation mode: default synthesis, JSON speaker embedding, model preset, x-vector voice clone, and ICL voice clone where available
+- cold-start versus warm-model timings
 
 The existing timing counters in `TTSTimingStats` already expose much of this information. The implementation plan should first determine whether those counters are sufficient or whether a small benchmark wrapper is needed.
 
@@ -50,6 +54,7 @@ Success criteria:
 - One documented CPU benchmark command.
 - One documented accelerator benchmark command when a backend is available.
 - Timing output that can show whether graph lifecycle overhead is material.
+- Fixed-seed or otherwise controlled runs that can be compared before and after optimization.
 
 ### Phase 2: Runtime Knob Cleanup
 
@@ -75,14 +80,14 @@ Success criteria:
 
 Use the benchmark data to reduce repeated scheduler work in the hottest safe path.
 
-Start with the code predictor. It runs once per generated frame and includes one prefill graph followed by 14 step graphs. This makes it the best candidate for reusable graph reservations or a small cache of stable graph variants.
+Start with the code predictor. It runs once per generated frame and includes one prefill graph followed by 14 step graphs. This makes it the best candidate for reusable scheduler reservations or a small cache of graph-shape metadata.
 
 The implementation should investigate these options in order:
 
 1. Reserve scheduler memory with a max-shape graph where GGML supports it.
-2. Reuse graph allocation for stable-shape predictor graphs.
+2. Rebuild graph metadata as needed, but avoid repeated backend buffer planning by reusing scheduler reservations for stable graph shapes.
 3. Keep input tensors in dedicated contexts where GGML allows static allocation.
-4. Only then consider larger structural changes such as unrolling the predictor sequence into fewer graph executions.
+4. Only then consider larger structural changes. Multi-step predictor fusion should be treated as a separate feasibility item, because each predictor step samples logits on the CPU and feeds the sampled code into the next step.
 
 Apply the same pattern to the talker step only if profiling shows graph build or allocation time is meaningful there.
 
@@ -91,6 +96,7 @@ Success criteria:
 - The graph optimization is guarded by tests or benchmarks that detect regressions.
 - Generated output remains compatible with the existing sampling and token generation behavior.
 - Backends that cannot benefit still run correctly.
+- The implementation does not cache raw `ggml_cgraph` pointers unless their backing metadata lifetime and input tensor allocation semantics are proven safe.
 
 ### Phase 4: Server Reuse
 
@@ -98,18 +104,22 @@ Add server-side reuse for work that does not need to be repeated on every reques
 
 Useful reuse candidates:
 
-- speaker embeddings
-- reference audio codec tokens
-- reference text tokenization
-- prompt structures for repeated voice clone or CustomVoice requests
+- ICL reference audio load/resample results
+- ICL reference speaker embeddings
+- ICL reference audio codec tokens
+- ICL reference text tokenization
+- prompt structures for repeated voice clone requests
+
+The server already caches JSON speaker embedding files at startup, so this phase should not spend effort re-solving that path. Model preset voice resolution may still benefit from avoiding repeated C API lookups, but only after profiling shows it matters.
 
 This phase should not change the core transformer math. It should reduce repeated setup latency in server mode and make repeated requests more comparable to the warm-cache behavior described by `faster-qwen3-tts`.
 
 Success criteria:
 
-- Repeated requests for the same voice avoid redundant prompt/reference preprocessing.
-- Cache keys include all inputs that affect output correctness.
+- Repeated ICL requests for the same reference avoid redundant load, resample, speaker-encoder, codec-encoder, and reference-token work.
+- Cache keys include all inputs that affect output correctness: model identity, mode, reference audio identity, reference audio content or mtime/size, reference text, language, and relevant synthesis parameters.
 - Cache size and invalidation behavior are explicit.
+- Cache access is safe under the existing server synthesis lock and does not imply new request-level concurrency.
 
 ### Phase 5: Static-Shape Decode Feasibility
 
@@ -122,7 +132,7 @@ This phase should start as a feasibility branch, not as an immediate production 
 Success criteria:
 
 - Clear proof that dynamic graph shape is a limiting factor after easier fixes.
-- Prefix-parity or perceptual-quality tests for generated codec tokens/audio.
+- Prefix-parity tests for generated codec tokens where deterministic comparison is possible, plus perceptual/audio checks where numeric identity is not expected.
 - Backend-specific fallbacks for unsupported cases.
 
 ## Architecture
@@ -139,6 +149,8 @@ If a reusable graph cache is introduced, it should be a small internal helper wi
 - invalidated when context size, backend, or model changes
 - hidden from public API consumers
 
+The first implementation should prefer a "reservation manager" over a broad "graph cache" abstraction. GGML documentation describes graph tensors as single-use for allocation but multi-use for computation, and input-bearing graphs may need fresh metadata after scheduler reset. The plan should therefore prove reuse semantics in a small slice before generalizing it across talker, predictor, encoder, and decoder graphs.
+
 ## Testing
 
 The implementation plan should include focused tests at three levels:
@@ -146,6 +158,8 @@ The implementation plan should include focused tests at three levels:
 - Unit or integration tests for thread-param propagation and cache key behavior.
 - Existing transformer tests to catch generation regressions.
 - Benchmark comparisons before and after graph lifecycle changes.
+- Deterministic token or prefix-parity checks for any graph lifecycle change that can affect generated codes.
+- Server tests for ICL cache hits, cache misses, invalidation, and wrong-key avoidance.
 
 Performance tests should report numbers but should not be brittle pass/fail checks unless a stable local fixture already exists.
 
@@ -153,8 +167,10 @@ Performance tests should report numbers but should not be brittle pass/fail chec
 
 - GGML graph tensors are not always reusable in the same way across backends.
 - `n_past` changes graph shape in the current talker path, which may limit reuse.
+- The code predictor step count looks fixed, but each step depends on CPU-side sampling from the previous step's logits; fusing steps would require moving sampling or changing semantics.
 - Static-shape attention masking could change numerical behavior even if the algorithm is equivalent.
 - Server caches can return wrong results if cache keys omit reference audio, reference text, language, speaker, or model identity.
+- Server caching reduces repeated preprocessing but does not remove the current single-synthesis lock or make the C API thread-safe.
 - Existing worktree changes are present, so implementation should keep future edits narrowly staged.
 
 ## Recommendation

--- a/server/README.md
+++ b/server/README.md
@@ -93,8 +93,20 @@ curl -X POST http://localhost:8000/v1/audio/speech \
 | `QWEN3TTS_VOICES_DIR` | `../voices` | Path to speaker embedding JSON files |
 | `QWEN3TTS_LIB_PATH` | (auto-detect) | Explicit path to `libqwen3tts.{so,dylib}` |
 | `QWEN3TTS_THREADS` | `4` | Number of compute threads |
+| `QWEN3TTS_ICL_CACHE_SIZE` | `8` | Maximum prepared ICL prompt handles to keep for repeated reference-audio requests. Set `0` to disable. |
 | `QWEN3TTS_HOST` | `0.0.0.0` | Server bind address |
 | `QWEN3TTS_PORT` | `8000` | Server port |
+
+## Runtime Caches and Concurrency
+
+The server keeps two voice-related caches:
+
+- JSON speaker embeddings from `QWEN3TTS_VOICES_DIR` are loaded at startup and reused for `voice` requests backed by `.json` embedding files.
+- ICL requests that provide `reference_audio_path` and `reference_text` use a bounded prepared-prompt cache controlled by `QWEN3TTS_ICL_CACHE_SIZE`. Entries store the native prepared prompt handle: reference audio speaker embedding, reference Mimi codec tokens, reference transcript, and related prompt metadata. They do not cache generated speech.
+
+ICL cache keys include role-specific model file identities for the TTS model, speaker encoder, codec encoder, and tokenizer/vocoder decoder; the reference audio path, size, and mtime; a hash of `reference_text`; and the language id. Some roles may point at the same GGUF file today, but they are tracked separately so future split-model layouts invalidate correctly.
+
+All synthesis paths still run under one process-local synthesis lock because the C API is not request-thread-safe. The ICL cache reduces repeated reference preparation latency; it does not enable parallel synthesis.
 
 ## OpenAI SDK Compatibility
 

--- a/server/icl_cache.py
+++ b/server/icl_cache.py
@@ -1,0 +1,130 @@
+"""Bounded cache for prepared ICL prompt handles."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from dataclasses import dataclass
+import hashlib
+import os
+from pathlib import Path
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class IclPromptCacheKey:
+    tts_model_path: str
+    tts_model_size: int
+    tts_model_mtime_ns: int
+    speaker_encoder_model_path: str
+    speaker_encoder_model_size: int
+    speaker_encoder_model_mtime_ns: int
+    codec_encoder_model_path: str
+    codec_encoder_model_size: int
+    codec_encoder_model_mtime_ns: int
+    tokenizer_decoder_model_path: str
+    tokenizer_decoder_model_size: int
+    tokenizer_decoder_model_mtime_ns: int
+    reference_path: str
+    reference_size: int
+    reference_mtime_ns: int
+    reference_text_hash: str
+    language_id: int
+
+
+def _file_identity(path: str) -> tuple[str, int, int]:
+    resolved = str(Path(path).expanduser().resolve())
+    st = os.stat(resolved)
+    return resolved, st.st_size, st.st_mtime_ns
+
+
+def _text_hash(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def build_icl_prompt_cache_key(
+    model_identities: Mapping[str, Mapping[str, Any]],
+    reference_path: str,
+    reference_text: str,
+    language_id: int,
+) -> IclPromptCacheKey:
+    """Build a cache key from resolved model-role identities and reference data."""
+
+    ref_path, ref_size, ref_mtime_ns = _file_identity(reference_path)
+
+    def role(name: str) -> Mapping[str, Any]:
+        try:
+            return model_identities[name]
+        except KeyError as exc:
+            raise KeyError(f"missing model identity role: {name}") from exc
+
+    tts = role("tts_model")
+    speaker = role("speaker_encoder_model")
+    codec = role("codec_encoder_model")
+    tokenizer = role("tokenizer_decoder_model")
+
+    return IclPromptCacheKey(
+        tts_model_path=str(tts["path"]),
+        tts_model_size=int(tts["size"]),
+        tts_model_mtime_ns=int(tts["mtime_ns"]),
+        speaker_encoder_model_path=str(speaker["path"]),
+        speaker_encoder_model_size=int(speaker["size"]),
+        speaker_encoder_model_mtime_ns=int(speaker["mtime_ns"]),
+        codec_encoder_model_path=str(codec["path"]),
+        codec_encoder_model_size=int(codec["size"]),
+        codec_encoder_model_mtime_ns=int(codec["mtime_ns"]),
+        tokenizer_decoder_model_path=str(tokenizer["path"]),
+        tokenizer_decoder_model_size=int(tokenizer["size"]),
+        tokenizer_decoder_model_mtime_ns=int(tokenizer["mtime_ns"]),
+        reference_path=ref_path,
+        reference_size=ref_size,
+        reference_mtime_ns=ref_mtime_ns,
+        reference_text_hash=_text_hash(reference_text),
+        language_id=int(language_id),
+    )
+
+
+class IclPromptCache:
+    """Small LRU cache that deterministically closes evicted prompt handles."""
+
+    def __init__(self, max_entries: int):
+        self._max_entries = max(0, int(max_entries))
+        self._entries: OrderedDict[IclPromptCacheKey, Any] = OrderedDict()
+
+    @property
+    def max_entries(self) -> int:
+        return self._max_entries
+
+    def get(self, key: IclPromptCacheKey):
+        value = self._entries.get(key)
+        if value is None:
+            return None
+        self._entries.move_to_end(key)
+        return value
+
+    def put(self, key: IclPromptCacheKey, value) -> None:
+        if self._max_entries <= 0:
+            self._close_value(value)
+            return
+
+        old = self._entries.pop(key, None)
+        if old is not None and old is not value:
+            self._close_value(old)
+
+        self._entries[key] = value
+        while len(self._entries) > self._max_entries:
+            _, evicted = self._entries.popitem(last=False)
+            self._close_value(evicted)
+
+    def clear(self) -> None:
+        while self._entries:
+            _, value = self._entries.popitem(last=False)
+            self._close_value(value)
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+    @staticmethod
+    def _close_value(value) -> None:
+        close = getattr(value, "close", None)
+        if close is not None:
+            close()

--- a/server/main.py
+++ b/server/main.py
@@ -4,6 +4,8 @@ Serves POST /v1/audio/speech following the OpenAI TTS API spec.
 Uses the qwen3-tts C shared library via ctypes.
 """
 
+from __future__ import annotations
+
 import array
 import asyncio
 import io
@@ -19,6 +21,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.responses import Response
 from pydantic import BaseModel, Field
 
+from icl_cache import IclPromptCache, build_icl_prompt_cache_key
 from qwen3_tts_binding import QwenTTS
 
 # ---------------------------------------------------------------------------
@@ -28,6 +31,8 @@ from qwen3_tts_binding import QwenTTS
 MODEL_DIR = os.environ.get("QWEN3TTS_MODEL_DIR", str(Path(__file__).parent.parent / "models"))
 VOICES_DIR = os.environ.get("QWEN3TTS_VOICES_DIR", str(Path(__file__).parent.parent / "voices"))
 N_THREADS = int(os.environ.get("QWEN3TTS_THREADS", "4"))
+ICL_CACHE_SIZE = int(os.environ.get("QWEN3TTS_ICL_CACHE_SIZE", "8"))
+DEFAULT_LANGUAGE_ID = 2050
 
 # ---------------------------------------------------------------------------
 # Global state
@@ -35,6 +40,7 @@ N_THREADS = int(os.environ.get("QWEN3TTS_THREADS", "4"))
 
 tts_engine: QwenTTS | None = None
 voice_embeddings: dict[str, list[float]] = {}
+icl_prompt_cache = IclPromptCache(ICL_CACHE_SIZE)
 _synthesis_lock = threading.Lock()  # C API is not thread-safe
 
 
@@ -63,8 +69,10 @@ async def lifespan(app: FastAPI):
     print(f"Scanning voices from: {VOICES_DIR}")
     load_voices()
     presets = tts_engine.list_speakers()
+    print(f"ICL prompt cache size: {icl_prompt_cache.max_entries}")
     print(f"Ready. {len(voice_embeddings)} JSON voice(s), {len(presets)} model preset(s).")
     yield
+    icl_prompt_cache.clear()
     if tts_engine:
         tts_engine.close()
         tts_engine = None
@@ -168,10 +176,34 @@ async def create_speech(request: SpeechRequest):
         try:
             def _do_icl():
                 with _synthesis_lock:
-                    return tts_engine.synthesize_icl(
-                        request.input, icl_ref_audio, icl_ref_text,
-                        temperature=temperature,
+                    cache_key = build_icl_prompt_cache_key(
+                        tts_engine.icl_model_identities,
+                        icl_ref_audio,
+                        icl_ref_text,
+                        DEFAULT_LANGUAGE_ID,
                     )
+                    prompt = icl_prompt_cache.get(cache_key)
+                    cache_enabled = icl_prompt_cache.max_entries > 0
+                    if prompt is not None:
+                        print(f"ICL prompt cache hit: {icl_ref_audio}")
+                    else:
+                        print(f"ICL prompt cache miss: {icl_ref_audio}")
+                        prompt = tts_engine.prepare_icl_prompt(
+                            icl_ref_audio, icl_ref_text,
+                            temperature=temperature,
+                            language_id=DEFAULT_LANGUAGE_ID,
+                        )
+                        if cache_enabled:
+                            icl_prompt_cache.put(cache_key, prompt)
+                    try:
+                        return tts_engine.synthesize_with_icl_prompt(
+                            request.input, prompt,
+                            temperature=temperature,
+                            language_id=DEFAULT_LANGUAGE_ID,
+                        )
+                    finally:
+                        if not cache_enabled:
+                            prompt.close()
             loop = asyncio.get_event_loop()
             samples, sample_rate = await loop.run_in_executor(None, _do_icl)
             wav_data = pcm_float32_to_wav(samples, sample_rate)

--- a/server/main.py
+++ b/server/main.py
@@ -72,10 +72,11 @@ async def lifespan(app: FastAPI):
     print(f"ICL prompt cache size: {icl_prompt_cache.max_entries}")
     print(f"Ready. {len(voice_embeddings)} JSON voice(s), {len(presets)} model preset(s).")
     yield
-    icl_prompt_cache.clear()
-    if tts_engine:
-        tts_engine.close()
-        tts_engine = None
+    with _synthesis_lock:
+        icl_prompt_cache.clear()
+        if tts_engine:
+            tts_engine.close()
+            tts_engine = None
 
 
 def _resolve_voice(voice: str):

--- a/server/qwen3_tts_binding.py
+++ b/server/qwen3_tts_binding.py
@@ -5,6 +5,7 @@ import ctypes.util
 import os
 import sys
 from pathlib import Path
+from typing import Optional
 
 
 # ---------------------------------------------------------------------------
@@ -172,8 +173,9 @@ class QwenTTS:
 
     def __init__(self, model_dir: str, n_threads: int = 4):
         self._lib = _load_library()
+        self._n_threads = n_threads if n_threads > 0 else 4
         self._handle = self._lib.qwen3_tts_create(
-            model_dir.encode("utf-8"), n_threads
+            model_dir.encode("utf-8"), self._n_threads
         )
         if not self._handle:
             raise RuntimeError(f"Failed to load models from {model_dir}")
@@ -186,11 +188,13 @@ class QwenTTS:
         language_id: int = 2050,
         max_audio_tokens: int = 2048,
         repetition_penalty: float = 1.05,
+        n_threads: Optional[int] = None,
     ) -> tuple[list[float], int]:
         """Synthesize text to audio. Returns (samples, sample_rate)."""
         params = self._make_params(
             temperature=temperature, top_k=top_k, language_id=language_id,
             max_audio_tokens=max_audio_tokens, repetition_penalty=repetition_penalty,
+            n_threads=n_threads if n_threads is not None else self._n_threads,
         )
         audio_ptr = self._lib.qwen3_tts_synthesize(
             self._handle, text.encode("utf-8"), ctypes.byref(params)
@@ -206,11 +210,13 @@ class QwenTTS:
         language_id: int = 2050,
         max_audio_tokens: int = 2048,
         repetition_penalty: float = 1.05,
+        n_threads: Optional[int] = None,
     ) -> tuple[list[float], int]:
         """Synthesize with a pre-computed speaker embedding."""
         params = self._make_params(
             temperature=temperature, top_k=top_k, language_id=language_id,
             max_audio_tokens=max_audio_tokens, repetition_penalty=repetition_penalty,
+            n_threads=n_threads if n_threads is not None else self._n_threads,
         )
         emb_arr = (ctypes.c_float * len(embedding))(*embedding)
         audio_ptr = self._lib.qwen3_tts_synthesize_with_embedding(
@@ -302,6 +308,7 @@ class QwenTTS:
         language_id: int = 2050,
         max_audio_tokens: int = 2048,
         repetition_penalty: float = 1.05,
+        n_threads: Optional[int] = None,
     ) -> tuple[list[float], int]:
         """Synthesize with in-context-learning voice cloning.
 
@@ -312,6 +319,7 @@ class QwenTTS:
         params = self._make_params(
             temperature=temperature, top_k=top_k, language_id=language_id,
             max_audio_tokens=max_audio_tokens, repetition_penalty=repetition_penalty,
+            n_threads=n_threads if n_threads is not None else self._n_threads,
         )
         audio_ptr = self._lib.qwen3_tts_synthesize_icl_file(
             self._handle, text.encode("utf-8"),
@@ -341,7 +349,10 @@ class QwenTTS:
     def _make_params(self, **kwargs) -> Qwen3TtsParams:
         params = Qwen3TtsParams()
         self._lib.qwen3_tts_default_params(ctypes.byref(params))
+        params.n_threads = self._n_threads
         for key, value in kwargs.items():
+            if value is None:
+                continue
             setattr(params, key, value)
         return params
 

--- a/server/qwen3_tts_binding.py
+++ b/server/qwen3_tts_binding.py
@@ -4,6 +4,7 @@ import ctypes
 import ctypes.util
 import os
 import sys
+import weakref
 from pathlib import Path
 from typing import Optional
 
@@ -120,6 +121,24 @@ def _load_library() -> ctypes.CDLL:
     ]
     lib.qwen3_tts_synthesize_icl_file.restype = ctypes.POINTER(Qwen3TtsAudio)
 
+    # -- qwen3_tts_prepare_icl_prompt_file --
+    lib.qwen3_tts_prepare_icl_prompt_file.argtypes = [
+        ctypes.c_void_p, ctypes.c_char_p, ctypes.c_char_p,
+        ctypes.POINTER(Qwen3TtsParams),
+    ]
+    lib.qwen3_tts_prepare_icl_prompt_file.restype = ctypes.c_void_p
+
+    # -- qwen3_tts_synthesize_with_icl_prompt --
+    lib.qwen3_tts_synthesize_with_icl_prompt.argtypes = [
+        ctypes.c_void_p, ctypes.c_char_p, ctypes.c_void_p,
+        ctypes.POINTER(Qwen3TtsParams),
+    ]
+    lib.qwen3_tts_synthesize_with_icl_prompt.restype = ctypes.POINTER(Qwen3TtsAudio)
+
+    # -- qwen3_tts_free_icl_prompt --
+    lib.qwen3_tts_free_icl_prompt.argtypes = [ctypes.c_void_p]
+    lib.qwen3_tts_free_icl_prompt.restype = None
+
     # -- qwen3_tts_sample_rate --
     lib.qwen3_tts_sample_rate.argtypes = [ctypes.c_void_p]
     lib.qwen3_tts_sample_rate.restype = ctypes.c_int32
@@ -142,6 +161,18 @@ def _load_library() -> ctypes.CDLL:
 
     lib.qwen3_tts_model_size.argtypes = [ctypes.c_void_p]
     lib.qwen3_tts_model_size.restype = ctypes.c_char_p
+
+    lib.qwen3_tts_tts_model_path.argtypes = [ctypes.c_void_p]
+    lib.qwen3_tts_tts_model_path.restype = ctypes.c_char_p
+
+    lib.qwen3_tts_speaker_encoder_model_path.argtypes = [ctypes.c_void_p]
+    lib.qwen3_tts_speaker_encoder_model_path.restype = ctypes.c_char_p
+
+    lib.qwen3_tts_codec_encoder_model_path.argtypes = [ctypes.c_void_p]
+    lib.qwen3_tts_codec_encoder_model_path.restype = ctypes.c_char_p
+
+    lib.qwen3_tts_tokenizer_decoder_model_path.argtypes = [ctypes.c_void_p]
+    lib.qwen3_tts_tokenizer_decoder_model_path.restype = ctypes.c_char_p
 
     lib.qwen3_tts_has_speaker_encoder.argtypes = [ctypes.c_void_p]
     lib.qwen3_tts_has_speaker_encoder.restype = ctypes.c_int
@@ -167,6 +198,34 @@ def _load_library() -> ctypes.CDLL:
 # ---------------------------------------------------------------------------
 # High-level wrapper
 # ---------------------------------------------------------------------------
+
+class _IclPromptHandle:
+    """Private owner for an opaque Qwen3TtsIclPrompt pointer."""
+
+    def __init__(self, lib: ctypes.CDLL, ptr):
+        if not ptr:
+            raise ValueError("null ICL prompt pointer")
+        self._lib = lib
+        self._ptr = ctypes.c_void_p(ptr)
+        self._finalizer = weakref.finalize(
+            self, _IclPromptHandle._free, self._lib, self._ptr
+        )
+
+    @staticmethod
+    def _free(lib: ctypes.CDLL, ptr: ctypes.c_void_p) -> None:
+        if ptr and ptr.value:
+            lib.qwen3_tts_free_icl_prompt(ptr)
+            ptr.value = None
+
+    def close(self) -> None:
+        self._finalizer()
+
+    @property
+    def _as_parameter_(self):
+        if not self._ptr or not self._ptr.value:
+            raise RuntimeError("ICL prompt handle is closed")
+        return self._ptr
+
 
 class QwenTTS:
     """High-level Python wrapper for the qwen3-tts C API."""
@@ -256,6 +315,16 @@ class QwenTTS:
         """True if the model ships an ECAPA-TDNN speaker encoder."""
         return bool(self._lib.qwen3_tts_has_speaker_encoder(self._handle))
 
+    @property
+    def icl_model_identities(self) -> dict[str, dict[str, object]]:
+        """Resolved role-specific model identities for ICL prompt cache keys."""
+        return {
+            "tts_model": self._model_file_identity(self._model_path("tts")),
+            "speaker_encoder_model": self._model_file_identity(self._model_path("speaker_encoder")),
+            "codec_encoder_model": self._model_file_identity(self._model_path("codec_encoder")),
+            "tokenizer_decoder_model": self._model_file_identity(self._model_path("tokenizer_decoder")),
+        }
+
     def list_speakers(self) -> list[dict]:
         """List preset voices baked into the model. Empty for Base variants.
 
@@ -329,6 +398,59 @@ class QwenTTS:
         )
         return self._extract_audio(audio_ptr)
 
+    def prepare_icl_prompt(
+        self,
+        reference_audio_path: str,
+        reference_text: str,
+        temperature: float = 0.9,
+        top_k: int = 50,
+        language_id: int = 2050,
+        max_audio_tokens: int = 2048,
+        repetition_penalty: float = 1.05,
+        n_threads: Optional[int] = None,
+    ) -> _IclPromptHandle:
+        """Prepare reusable ICL prompt state from reference audio and text."""
+        params = self._make_params(
+            temperature=temperature, top_k=top_k, language_id=language_id,
+            max_audio_tokens=max_audio_tokens, repetition_penalty=repetition_penalty,
+            n_threads=n_threads if n_threads is not None else self._n_threads,
+        )
+        ptr = self._lib.qwen3_tts_prepare_icl_prompt_file(
+            self._handle,
+            reference_audio_path.encode("utf-8"),
+            reference_text.encode("utf-8"),
+            ctypes.byref(params),
+        )
+        if not ptr:
+            err = self._get_error()
+            raise RuntimeError(f"Failed to prepare ICL prompt: {err}")
+        return _IclPromptHandle(self._lib, ptr)
+
+    def synthesize_with_icl_prompt(
+        self,
+        text: str,
+        prompt_handle: _IclPromptHandle,
+        temperature: float = 0.9,
+        top_k: int = 50,
+        language_id: int = 2050,
+        max_audio_tokens: int = 2048,
+        repetition_penalty: float = 1.05,
+        n_threads: Optional[int] = None,
+    ) -> tuple[list[float], int]:
+        """Synthesize with a prepared ICL prompt handle."""
+        params = self._make_params(
+            temperature=temperature, top_k=top_k, language_id=language_id,
+            max_audio_tokens=max_audio_tokens, repetition_penalty=repetition_penalty,
+            n_threads=n_threads if n_threads is not None else self._n_threads,
+        )
+        audio_ptr = self._lib.qwen3_tts_synthesize_with_icl_prompt(
+            self._handle,
+            text.encode("utf-8"),
+            prompt_handle,
+            ctypes.byref(params),
+        )
+        return self._extract_audio(audio_ptr)
+
     def close(self):
         """Destroy the engine and release resources."""
         if self._handle:
@@ -372,3 +494,23 @@ class QwenTTS:
     def _get_error(self) -> str:
         err = self._lib.qwen3_tts_get_error(self._handle)
         return err.decode("utf-8") if err else "unknown error"
+
+    def _model_path(self, role: str) -> str:
+        funcs = {
+            "tts": self._lib.qwen3_tts_tts_model_path,
+            "speaker_encoder": self._lib.qwen3_tts_speaker_encoder_model_path,
+            "codec_encoder": self._lib.qwen3_tts_codec_encoder_model_path,
+            "tokenizer_decoder": self._lib.qwen3_tts_tokenizer_decoder_model_path,
+        }
+        raw = funcs[role](self._handle)
+        return raw.decode("utf-8") if raw else ""
+
+    @staticmethod
+    def _model_file_identity(path: str) -> dict[str, object]:
+        resolved = Path(path).expanduser().resolve()
+        st = resolved.stat()
+        return {
+            "path": str(resolved),
+            "size": st.st_size,
+            "mtime_ns": st.st_mtime_ns,
+        }

--- a/server/tests/test_icl_cache.py
+++ b/server/tests/test_icl_cache.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Pure standard-library tests for the ICL prompt cache."""
+
+import hashlib
+import os
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from icl_cache import IclPromptCache, IclPromptCacheKey
+
+
+class CloseTrackingPrompt:
+    def __init__(self, name):
+        self.name = name
+        self.close_count = 0
+
+    def close(self):
+        self.close_count += 1
+
+
+def file_identity(path):
+    st = os.stat(path)
+    return str(Path(path).resolve()), st.st_size, st.st_mtime_ns
+
+
+def make_key(reference_path, reference_text="hello", language_id=2050, model_suffix="a"):
+    ref_path, ref_size, ref_mtime_ns = file_identity(reference_path)
+    ref_hash = hashlib.sha256(reference_text.encode("utf-8")).hexdigest()
+    return IclPromptCacheKey(
+        tts_model_path=f"/models/tts-{model_suffix}.gguf",
+        tts_model_size=100,
+        tts_model_mtime_ns=1000,
+        speaker_encoder_model_path=f"/models/speaker-{model_suffix}.gguf",
+        speaker_encoder_model_size=101,
+        speaker_encoder_model_mtime_ns=1001,
+        codec_encoder_model_path=f"/models/codec-{model_suffix}.gguf",
+        codec_encoder_model_size=102,
+        codec_encoder_model_mtime_ns=1002,
+        tokenizer_decoder_model_path=f"/models/tokenizer-{model_suffix}.gguf",
+        tokenizer_decoder_model_size=103,
+        tokenizer_decoder_model_mtime_ns=1003,
+        reference_path=ref_path,
+        reference_size=ref_size,
+        reference_mtime_ns=ref_mtime_ns,
+        reference_text_hash=ref_hash,
+        language_id=language_id,
+    )
+
+
+class IclPromptCacheTests(unittest.TestCase):
+    def test_same_inputs_produce_same_key(self):
+        with tempfile.NamedTemporaryFile() as ref:
+            ref.write(b"audio")
+            ref.flush()
+            key_a = make_key(ref.name)
+            key_b = make_key(ref.name)
+
+        self.assertEqual(key_a, key_b)
+        self.assertEqual(hash(key_a), hash(key_b))
+
+    def test_changed_model_identity_changes_key(self):
+        with tempfile.NamedTemporaryFile() as ref:
+            ref.write(b"audio")
+            ref.flush()
+            key_a = make_key(ref.name, model_suffix="a")
+            key_b = make_key(ref.name, model_suffix="b")
+
+        self.assertNotEqual(key_a, key_b)
+
+    def test_changed_reference_text_changes_key(self):
+        with tempfile.NamedTemporaryFile() as ref:
+            ref.write(b"audio")
+            ref.flush()
+            key_a = make_key(ref.name, reference_text="hello")
+            key_b = make_key(ref.name, reference_text="different")
+
+        self.assertNotEqual(key_a, key_b)
+
+    def test_changed_reference_file_mtime_or_size_changes_key(self):
+        with tempfile.NamedTemporaryFile(delete=False) as ref:
+            ref.write(b"audio")
+            ref.flush()
+            ref_path = ref.name
+
+        try:
+            key_a = make_key(ref_path)
+            time.sleep(0.001)
+            with open(ref_path, "ab") as f:
+                f.write(b"-changed")
+            os.utime(ref_path, None)
+            key_b = make_key(ref_path)
+        finally:
+            os.unlink(ref_path)
+
+        self.assertNotEqual(key_a, key_b)
+        self.assertNotEqual(key_a.reference_size, key_b.reference_size)
+        self.assertNotEqual(key_a.reference_mtime_ns, key_b.reference_mtime_ns)
+
+    def test_lru_eviction_removes_oldest_entry(self):
+        cache = IclPromptCache(max_entries=2)
+        with tempfile.NamedTemporaryFile() as ref:
+            ref.write(b"audio")
+            ref.flush()
+            key_a = make_key(ref.name, reference_text="a")
+            key_b = make_key(ref.name, reference_text="b")
+            key_c = make_key(ref.name, reference_text="c")
+
+        prompt_a = CloseTrackingPrompt("a")
+        prompt_b = CloseTrackingPrompt("b")
+        prompt_c = CloseTrackingPrompt("c")
+        cache.put(key_a, prompt_a)
+        cache.put(key_b, prompt_b)
+        self.assertIs(cache.get(key_a), prompt_a)
+        cache.put(key_c, prompt_c)
+
+        self.assertIs(cache.get(key_a), prompt_a)
+        self.assertIsNone(cache.get(key_b))
+        self.assertIs(cache.get(key_c), prompt_c)
+        self.assertEqual(prompt_b.close_count, 1)
+        self.assertEqual(prompt_a.close_count, 0)
+        self.assertEqual(prompt_c.close_count, 0)
+
+    def test_clear_explicitly_closes_cached_values(self):
+        cache = IclPromptCache(max_entries=4)
+        with tempfile.NamedTemporaryFile() as ref:
+            ref.write(b"audio")
+            ref.flush()
+            key_a = make_key(ref.name, reference_text="a")
+            key_b = make_key(ref.name, reference_text="b")
+
+        prompt_a = CloseTrackingPrompt("a")
+        prompt_b = CloseTrackingPrompt("b")
+        cache.put(key_a, prompt_a)
+        cache.put(key_b, prompt_b)
+
+        cache.clear()
+
+        self.assertIsNone(cache.get(key_a))
+        self.assertIsNone(cache.get(key_b))
+        self.assertEqual(prompt_a.close_count, 1)
+        self.assertEqual(prompt_b.close_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/common/backend_threads.cpp
+++ b/src/common/backend_threads.cpp
@@ -1,0 +1,48 @@
+#include "common/backend_threads.h"
+
+#include "ggml-cpu.h"
+
+#include <atomic>
+
+namespace qwen3_tts {
+
+namespace {
+std::atomic<int32_t> g_default_backend_n_threads{4};
+}
+
+bool apply_backend_n_threads(ggml_backend_t backend, int32_t n_threads) {
+    if (!backend || n_threads <= 0) {
+        return false;
+    }
+
+    ggml_backend_dev_t dev = ggml_backend_get_device(backend);
+    ggml_backend_reg_t reg = dev ? ggml_backend_dev_backend_reg(dev) : nullptr;
+    if (reg) {
+        auto set_n_threads =
+            reinterpret_cast<ggml_backend_set_n_threads_t>(
+                ggml_backend_reg_get_proc_address(reg, "ggml_backend_set_n_threads"));
+        if (set_n_threads) {
+            set_n_threads(backend, n_threads);
+            return true;
+        }
+    }
+
+    if (ggml_backend_is_cpu(backend)) {
+        ggml_backend_cpu_set_n_threads(backend, n_threads);
+        return true;
+    }
+
+    return false;
+}
+
+void set_default_backend_n_threads(int32_t n_threads) {
+    if (n_threads > 0) {
+        g_default_backend_n_threads.store(n_threads, std::memory_order_relaxed);
+    }
+}
+
+int32_t get_default_backend_n_threads() {
+    return g_default_backend_n_threads.load(std::memory_order_relaxed);
+}
+
+} // namespace qwen3_tts

--- a/src/common/backend_threads.h
+++ b/src/common/backend_threads.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "ggml-backend.h"
+
+#include <cstdint>
+
+namespace qwen3_tts {
+
+bool apply_backend_n_threads(ggml_backend_t backend, int32_t n_threads);
+void set_default_backend_n_threads(int32_t n_threads);
+int32_t get_default_backend_n_threads();
+
+} // namespace qwen3_tts

--- a/src/common/benchmark_json.cpp
+++ b/src/common/benchmark_json.cpp
@@ -91,7 +91,7 @@ std::string benchmark_record_to_json(const benchmark_record & r) {
     append_string(out, first, "model_type", r.model_type);
     append_string(out, first, "model_size", r.model_size);
     append_string(out, first, "tts_model", r.tts_model);
-    append_string(out, first, "tokenizer_model", r.tokenizer_model);
+    append_string(out, first, "decoder_model", r.decoder_model);
     append_string(out, first, "quantization", r.quantization);
     append_string(out, first, "text", r.text);
     append_double(out, first, "audio_seconds", r.audio_seconds);

--- a/src/common/benchmark_json.cpp
+++ b/src/common/benchmark_json.cpp
@@ -1,0 +1,167 @@
+#include "common/benchmark_json.h"
+
+#include <cmath>
+#include <fstream>
+#include <iomanip>
+#include <sstream>
+
+namespace qwen3_tts {
+namespace {
+
+void append_escaped_string(std::ostringstream & out, const std::string & value) {
+    out << '"';
+    for (unsigned char c : value) {
+        switch (c) {
+            case '"':  out << "\\\""; break;
+            case '\\': out << "\\\\"; break;
+            case '\b': out << "\\b"; break;
+            case '\f': out << "\\f"; break;
+            case '\n': out << "\\n"; break;
+            case '\r': out << "\\r"; break;
+            case '\t': out << "\\t"; break;
+            default:
+                if (c < 0x20) {
+                    out << "\\u" << std::hex << std::setw(4) << std::setfill('0')
+                        << static_cast<int>(c) << std::dec << std::setfill(' ');
+                } else {
+                    out << static_cast<char>(c);
+                }
+                break;
+        }
+    }
+    out << '"';
+}
+
+void append_key(std::ostringstream & out, bool & first, const char * key) {
+    if (!first) {
+        out << ',';
+    }
+    first = false;
+    append_escaped_string(out, key);
+    out << ':';
+}
+
+void append_string(std::ostringstream & out, bool & first,
+                   const char * key, const std::string & value) {
+    append_key(out, first, key);
+    append_escaped_string(out, value);
+}
+
+void append_i64(std::ostringstream & out, bool & first, const char * key, int64_t value) {
+    append_key(out, first, key);
+    out << value;
+}
+
+void append_u64(std::ostringstream & out, bool & first, const char * key, uint64_t value) {
+    append_key(out, first, key);
+    out << value;
+}
+
+void append_i32(std::ostringstream & out, bool & first, const char * key, int32_t value) {
+    append_key(out, first, key);
+    out << value;
+}
+
+void append_double(std::ostringstream & out, bool & first, const char * key, double value) {
+    append_key(out, first, key);
+    if (std::isfinite(value)) {
+        out << value;
+    } else {
+        out << "null";
+    }
+}
+
+void append_bool(std::ostringstream & out, bool & first, const char * key, bool value) {
+    append_key(out, first, key);
+    out << (value ? "true" : "false");
+}
+
+} // namespace
+
+std::string benchmark_record_to_json(const benchmark_record & r) {
+    std::ostringstream out;
+    out << std::setprecision(15);
+
+    bool first = true;
+    out << '{';
+    append_string(out, first, "mode", r.mode);
+    append_string(out, first, "backend", r.backend);
+    append_string(out, first, "device", r.device);
+    append_i32(out, first, "thread_count", r.thread_count);
+    append_string(out, first, "model_type", r.model_type);
+    append_string(out, first, "model_size", r.model_size);
+    append_string(out, first, "tts_model", r.tts_model);
+    append_string(out, first, "tokenizer_model", r.tokenizer_model);
+    append_string(out, first, "quantization", r.quantization);
+    append_string(out, first, "text", r.text);
+    append_double(out, first, "audio_seconds", r.audio_seconds);
+
+    if (r.audio_seconds > 0.0 && r.total_ms > 0) {
+        const double total_seconds = static_cast<double>(r.total_ms) / 1000.0;
+        append_double(out, first, "speed_x_realtime", r.audio_seconds / total_seconds);
+        append_double(out, first, "wall_rtf", total_seconds / r.audio_seconds);
+    }
+
+    append_i64(out, first, "tokenize_ms", r.tokenize_ms);
+    append_i64(out, first, "encode_ms", r.encode_ms);
+    append_i64(out, first, "generate_ms", r.generate_ms);
+    append_i64(out, first, "decode_ms", r.decode_ms);
+    append_i64(out, first, "total_ms", r.total_ms);
+
+    append_u64(out, first, "mem_rss_start_bytes", r.mem_rss_start_bytes);
+    append_u64(out, first, "mem_rss_end_bytes", r.mem_rss_end_bytes);
+    append_u64(out, first, "mem_rss_peak_bytes", r.mem_rss_peak_bytes);
+    append_u64(out, first, "mem_phys_start_bytes", r.mem_phys_start_bytes);
+    append_u64(out, first, "mem_phys_end_bytes", r.mem_phys_end_bytes);
+    append_u64(out, first, "mem_phys_peak_bytes", r.mem_phys_peak_bytes);
+
+    append_bool(out, first, "has_detailed_timing", r.has_detailed_timing);
+    if (r.has_detailed_timing) {
+        append_double(out, first, "prefill_build_ms", r.prefill_build_ms);
+        append_double(out, first, "prefill_forward_ms", r.prefill_forward_ms);
+        append_double(out, first, "prefill_graph_build_ms", r.prefill_graph_build_ms);
+        append_double(out, first, "prefill_graph_alloc_ms", r.prefill_graph_alloc_ms);
+        append_double(out, first, "prefill_compute_ms", r.prefill_compute_ms);
+        append_double(out, first, "prefill_data_ms", r.prefill_data_ms);
+        append_double(out, first, "talker_forward_ms", r.talker_forward_ms);
+        append_double(out, first, "talker_graph_build_ms", r.talker_graph_build_ms);
+        append_double(out, first, "talker_graph_alloc_ms", r.talker_graph_alloc_ms);
+        append_double(out, first, "talker_compute_ms", r.talker_compute_ms);
+        append_double(out, first, "talker_data_ms", r.talker_data_ms);
+        append_double(out, first, "code_pred_ms", r.code_pred_ms);
+        append_double(out, first, "code_pred_init_ms", r.code_pred_init_ms);
+        append_double(out, first, "code_pred_prefill_ms", r.code_pred_prefill_ms);
+        append_double(out, first, "code_pred_steps_ms", r.code_pred_steps_ms);
+        append_double(out, first, "code_pred_graph_build_ms", r.code_pred_graph_build_ms);
+        append_double(out, first, "code_pred_graph_alloc_ms", r.code_pred_graph_alloc_ms);
+        append_double(out, first, "code_pred_compute_ms", r.code_pred_compute_ms);
+        append_double(out, first, "code_pred_data_ms", r.code_pred_data_ms);
+        append_double(out, first, "code_pred_coreml_ms", r.code_pred_coreml_ms);
+        append_double(out, first, "embed_lookup_ms", r.embed_lookup_ms);
+        append_i32(out, first, "frames", r.frames);
+        append_double(out, first, "generate_total_ms", r.generate_total_ms);
+    }
+    out << "}\n";
+    return out.str();
+}
+
+bool write_benchmark_record_json(const std::string & path,
+                                 const benchmark_record & r,
+                                 std::string & error) {
+    std::ofstream file(path, std::ios::out | std::ios::trunc);
+    if (!file) {
+        error = "failed to open benchmark JSON file: " + path;
+        return false;
+    }
+
+    file << benchmark_record_to_json(r);
+    if (!file) {
+        error = "failed to write benchmark JSON file: " + path;
+        return false;
+    }
+
+    error.clear();
+    return true;
+}
+
+} // namespace qwen3_tts

--- a/src/common/benchmark_json.h
+++ b/src/common/benchmark_json.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace qwen3_tts {
+
+struct benchmark_record {
+    std::string mode;
+    std::string backend;
+    std::string device;
+    int32_t thread_count = 0;
+
+    std::string model_type;
+    std::string model_size;
+    std::string tts_model;
+    std::string tokenizer_model;
+    std::string quantization;
+
+    std::string text;
+    double audio_seconds = 0.0;
+
+    int64_t tokenize_ms = 0;
+    int64_t encode_ms = 0;
+    int64_t generate_ms = 0;
+    int64_t decode_ms = 0;
+    int64_t total_ms = 0;
+
+    uint64_t mem_rss_start_bytes = 0;
+    uint64_t mem_rss_end_bytes = 0;
+    uint64_t mem_rss_peak_bytes = 0;
+    uint64_t mem_phys_start_bytes = 0;
+    uint64_t mem_phys_end_bytes = 0;
+    uint64_t mem_phys_peak_bytes = 0;
+
+    bool has_detailed_timing = false;
+    double prefill_build_ms = 0.0;
+    double prefill_forward_ms = 0.0;
+    double prefill_graph_build_ms = 0.0;
+    double prefill_graph_alloc_ms = 0.0;
+    double prefill_compute_ms = 0.0;
+    double prefill_data_ms = 0.0;
+    double talker_forward_ms = 0.0;
+    double talker_graph_build_ms = 0.0;
+    double talker_graph_alloc_ms = 0.0;
+    double talker_compute_ms = 0.0;
+    double talker_data_ms = 0.0;
+    double code_pred_ms = 0.0;
+    double code_pred_init_ms = 0.0;
+    double code_pred_prefill_ms = 0.0;
+    double code_pred_steps_ms = 0.0;
+    double code_pred_graph_build_ms = 0.0;
+    double code_pred_graph_alloc_ms = 0.0;
+    double code_pred_compute_ms = 0.0;
+    double code_pred_data_ms = 0.0;
+    double code_pred_coreml_ms = 0.0;
+    double embed_lookup_ms = 0.0;
+    int32_t frames = 0;
+    double generate_total_ms = 0.0;
+};
+
+std::string benchmark_record_to_json(const benchmark_record & r);
+bool write_benchmark_record_json(const std::string & path,
+                                 const benchmark_record & r,
+                                 std::string & error);
+
+} // namespace qwen3_tts

--- a/src/common/benchmark_json.h
+++ b/src/common/benchmark_json.h
@@ -14,7 +14,7 @@ struct benchmark_record {
     std::string model_type;
     std::string model_size;
     std::string tts_model;
-    std::string tokenizer_model;
+    std::string decoder_model;
     std::string quantization;
 
     std::string text;

--- a/src/common/gguf_loader.cpp
+++ b/src/common/gguf_loader.cpp
@@ -1,4 +1,5 @@
 #include "common/gguf_loader.h"
+#include "common/backend_threads.h"
 
 #include <cerrno>
 #include <climits>
@@ -156,6 +157,7 @@ ggml_backend_t init_preferred_backend(const char * component_name, std::string *
 
     auto & shared = get_shared_backend_state();
     if (shared.backend) {
+        apply_backend_n_threads(shared.backend, get_default_backend_n_threads());
         shared.ref_count++;
         return shared.backend;
     }
@@ -190,11 +192,20 @@ ggml_backend_t init_preferred_backend(const char * component_name, std::string *
     }
 
     if (backend) {
+        apply_backend_n_threads(backend, get_default_backend_n_threads());
         shared.backend = backend;
         shared.ref_count = 1;
     }
 
     return backend;
+}
+
+bool apply_default_backend_threads_to_preferred_backend() {
+    auto & shared = get_shared_backend_state();
+    if (!shared.backend) {
+        return false;
+    }
+    return apply_backend_n_threads(shared.backend, get_default_backend_n_threads());
 }
 
 void release_preferred_backend(ggml_backend_t backend) {

--- a/src/common/gguf_loader.h
+++ b/src/common/gguf_loader.h
@@ -76,6 +76,7 @@ bool load_tensor_data_from_file(
 // Helper to initialize backend with GPU preference and CPU fallback
 ggml_backend_t init_preferred_backend(const char * component_name, std::string * error_msg);
 void release_preferred_backend(ggml_backend_t backend);
+bool apply_default_backend_threads_to_preferred_backend();
 
 // Helper function to free model resources
 void free_ggml_resources(struct ggml_context * ctx, ggml_backend_buffer_t buffer);

--- a/src/decoder/audio_tokenizer_decoder.cpp
+++ b/src/decoder/audio_tokenizer_decoder.cpp
@@ -1,4 +1,5 @@
 #include "decoder/audio_tokenizer_decoder.h"
+#include "common/backend_threads.h"
 #include "common/gguf_loader.h"
 #include "ggml-cpu.h"
 
@@ -420,6 +421,7 @@ bool AudioTokenizerDecoder::load_model(const std::string & model_path) {
             error_msg_ = "Failed to initialize CPU fallback backend for AudioTokenizerDecoder";
             return fail_after_context_created();
         }
+        apply_backend_n_threads(state_.backend_cpu, get_default_backend_n_threads());
     }
 
     if (!create_decoder_scheduler(state_, error_msg_)) {
@@ -557,6 +559,21 @@ bool AudioTokenizerDecoder::require_weights_gpu_resident() {
         return false;
     }
     return true;
+}
+
+bool AudioTokenizerDecoder::set_n_threads(int32_t n_threads) {
+    if (n_threads <= 0) {
+        return false;
+    }
+
+    bool applied = false;
+    if (state_.backend) {
+        applied = apply_backend_n_threads(state_.backend, n_threads) || applied;
+    }
+    if (state_.backend_cpu) {
+        applied = apply_backend_n_threads(state_.backend_cpu, n_threads) || applied;
+    }
+    return applied;
 }
 
 struct ggml_tensor * AudioTokenizerDecoder::apply_snake(struct ggml_context * ctx,

--- a/src/decoder/audio_tokenizer_decoder.h
+++ b/src/decoder/audio_tokenizer_decoder.h
@@ -189,6 +189,9 @@ public:
     const audio_decoder_config & get_config() const { return model_.config; }
     
     const std::string & get_error() const { return error_msg_; }
+
+    // Apply thread count to loaded GGML backends where supported.
+    bool set_n_threads(int32_t n_threads);
     
 private:
     friend class Qwen3TTS;

--- a/src/encoder/audio_codec_encoder.cpp
+++ b/src/encoder/audio_codec_encoder.cpp
@@ -4,6 +4,7 @@
 // talker's codec vocabulary — the "codes" path for CustomVoice-style cloning.
 
 #include "encoder/audio_codec_encoder.h"
+#include "common/backend_threads.h"
 #include "common/gguf_loader.h"
 #include "ggml-cpu.h"
 
@@ -253,6 +254,7 @@ bool AudioCodecEncoder::load_model(const std::string & model_path) {
             error_msg_ = "failed to init CPU fallback for AudioCodecEncoder";
             return false;
         }
+        apply_backend_n_threads(state_.backend_cpu, get_default_backend_n_threads());
     }
 
     std::vector<ggml_backend_t> backends;
@@ -267,6 +269,21 @@ bool AudioCodecEncoder::load_model(const std::string & model_path) {
 
     state_.compute_meta.resize(ggml_tensor_overhead() * ENC_MAX_NODES + ggml_graph_overhead());
     return true;
+}
+
+bool AudioCodecEncoder::set_n_threads(int32_t n_threads) {
+    if (n_threads <= 0) {
+        return false;
+    }
+
+    bool applied = false;
+    if (state_.backend) {
+        applied = apply_backend_n_threads(state_.backend, n_threads) || applied;
+    }
+    if (state_.backend_cpu) {
+        applied = apply_backend_n_threads(state_.backend_cpu, n_threads) || applied;
+    }
+    return applied;
 }
 
 // --- graph building --------------------------------------------------------

--- a/src/encoder/audio_codec_encoder.h
+++ b/src/encoder/audio_codec_encoder.h
@@ -121,6 +121,9 @@ public:
     const codec_encoder_config & get_config() const { return model_.config; }
     const std::string & get_error() const { return error_msg_; }
 
+    // Apply thread count to loaded GGML backends where supported.
+    bool set_n_threads(int32_t n_threads);
+
 private:
     struct ggml_cgraph * build_graph(int32_t n_samples);
 

--- a/src/encoder/audio_tokenizer_encoder.cpp
+++ b/src/encoder/audio_tokenizer_encoder.cpp
@@ -1,4 +1,5 @@
 #include "encoder/audio_tokenizer_encoder.h"
+#include "common/backend_threads.h"
 #include "common/gguf_loader.h"
 #include "ggml-cpu.h"
 
@@ -278,6 +279,7 @@ bool AudioTokenizerEncoder::load_model(const std::string & model_path) {
         if (!state_.backend_cpu) {
             return fail_load("Failed to initialize CPU fallback backend for AudioTokenizerEncoder");
         }
+        apply_backend_n_threads(state_.backend_cpu, get_default_backend_n_threads());
     }
 
     std::vector<ggml_backend_t> backends;
@@ -293,6 +295,21 @@ bool AudioTokenizerEncoder::load_model(const std::string & model_path) {
     state_.compute_meta.resize(ggml_tensor_overhead() * QWEN3_TTS_MAX_NODES + ggml_graph_overhead());
     
     return true;
+}
+
+bool AudioTokenizerEncoder::set_n_threads(int32_t n_threads) {
+    if (n_threads <= 0) {
+        return false;
+    }
+
+    bool applied = false;
+    if (state_.backend) {
+        applied = apply_backend_n_threads(state_.backend, n_threads) || applied;
+    }
+    if (state_.backend_cpu) {
+        applied = apply_backend_n_threads(state_.backend_cpu, n_threads) || applied;
+    }
+    return applied;
 }
 
 bool AudioTokenizerEncoder::compute_mel_spectrogram(const float * samples, int32_t n_samples,

--- a/src/encoder/audio_tokenizer_encoder.h
+++ b/src/encoder/audio_tokenizer_encoder.h
@@ -130,6 +130,9 @@ public:
     const speaker_encoder_config & get_config() const { return model_.config; }
     
     const std::string & get_error() const { return error_msg_; }
+
+    // Apply thread count to loaded GGML backends where supported.
+    bool set_n_threads(int32_t n_threads);
     
 private:
     // Compute mel spectrogram from waveform

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,7 +43,7 @@ qwen3_tts::benchmark_record make_benchmark_record(const qwen3_tts::Qwen3TTS & tt
     record.mode = mode;
     record.backend = env_or_default("QWEN3_TTS_BACKEND", "auto");
     record.device = env_or_default("QWEN3_TTS_DEVICE", "");
-    record.thread_count = params.n_threads;
+    record.thread_count = params.n_threads > 0 ? params.n_threads : tts.get_n_threads();
     record.model_type = tts.get_model_type();
     record.model_size = tts.get_model_size();
     record.tts_model = basename_of(tts.get_tts_model_path());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,7 +47,7 @@ qwen3_tts::benchmark_record make_benchmark_record(const qwen3_tts::Qwen3TTS & tt
     record.model_type = tts.get_model_type();
     record.model_size = tts.get_model_size();
     record.tts_model = basename_of(tts.get_tts_model_path());
-    record.tokenizer_model = basename_of(tts.get_decoder_model_path());
+    record.decoder_model = basename_of(tts.get_decoder_model_path());
     record.quantization = infer_quantization(record.tts_model);
     record.text = text;
     record.audio_seconds = result.sample_rate > 0

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,10 +1,104 @@
 #include "pipeline/qwen3_tts.h"
+#include "common/benchmark_json.h"
 #include "common/speaker_embedding_io.h"
 
+#include <cstdlib>
 #include <cstdio>
 #include <cstring>
 #include <string>
 #include <vector>
+
+namespace {
+
+std::string basename_of(const std::string & path) {
+    const size_t pos = path.find_last_of("/\\");
+    return pos == std::string::npos ? path : path.substr(pos + 1);
+}
+
+std::string env_or_default(const char * name, const char * fallback) {
+    const char * value = std::getenv(name);
+    return value && value[0] != '\0' ? std::string(value) : std::string(fallback);
+}
+
+std::string infer_quantization(const std::string & model_name) {
+    const std::string name = basename_of(model_name);
+    const char * known[] = {
+        "q2_k", "q3_k", "q4_0", "q4_1", "q4_k", "q5_0", "q5_1",
+        "q5_k", "q6_k", "q8_0", "f16", "f32"
+    };
+    for (const char * q : known) {
+        if (name.find(q) != std::string::npos) {
+            return q;
+        }
+    }
+    return std::string();
+}
+
+qwen3_tts::benchmark_record make_benchmark_record(const qwen3_tts::Qwen3TTS & tts,
+                                                   const qwen3_tts::tts_result & result,
+                                                   const qwen3_tts::tts_params & params,
+                                                   const std::string & mode,
+                                                   const std::string & text) {
+    qwen3_tts::benchmark_record record;
+    record.mode = mode;
+    record.backend = env_or_default("QWEN3_TTS_BACKEND", "auto");
+    record.device = env_or_default("QWEN3_TTS_DEVICE", "");
+    record.thread_count = params.n_threads;
+    record.model_type = tts.get_model_type();
+    record.model_size = tts.get_model_size();
+    record.tts_model = basename_of(tts.get_tts_model_path());
+    record.tokenizer_model = basename_of(tts.get_decoder_model_path());
+    record.quantization = infer_quantization(record.tts_model);
+    record.text = text;
+    record.audio_seconds = result.sample_rate > 0
+        ? static_cast<double>(result.audio.size()) / static_cast<double>(result.sample_rate)
+        : 0.0;
+    record.tokenize_ms = result.t_tokenize_ms;
+    record.encode_ms = result.t_encode_ms;
+    record.generate_ms = result.t_generate_ms;
+    record.decode_ms = result.t_decode_ms;
+    record.total_ms = result.t_total_ms;
+    record.mem_rss_start_bytes = result.mem_rss_start_bytes;
+    record.mem_rss_end_bytes = result.mem_rss_end_bytes;
+    record.mem_rss_peak_bytes = result.mem_rss_peak_bytes;
+    record.mem_phys_start_bytes = result.mem_phys_start_bytes;
+    record.mem_phys_end_bytes = result.mem_phys_end_bytes;
+    record.mem_phys_peak_bytes = result.mem_phys_peak_bytes;
+
+#ifdef QWEN3_TTS_TIMING
+    if (result.has_detailed_timing) {
+        const qwen3_tts::tts_timing & timing = result.detailed_timing;
+        record.has_detailed_timing = true;
+        record.prefill_build_ms = timing.t_prefill_build_ms;
+        record.prefill_forward_ms = timing.t_prefill_forward_ms;
+        record.prefill_graph_build_ms = timing.t_prefill_graph_build_ms;
+        record.prefill_graph_alloc_ms = timing.t_prefill_graph_alloc_ms;
+        record.prefill_compute_ms = timing.t_prefill_compute_ms;
+        record.prefill_data_ms = timing.t_prefill_data_ms;
+        record.talker_forward_ms = timing.t_talker_forward_ms;
+        record.talker_graph_build_ms = timing.t_talker_graph_build_ms;
+        record.talker_graph_alloc_ms = timing.t_talker_graph_alloc_ms;
+        record.talker_compute_ms = timing.t_talker_compute_ms;
+        record.talker_data_ms = timing.t_talker_data_ms;
+        record.code_pred_ms = timing.t_code_pred_ms;
+        record.code_pred_init_ms = timing.t_code_pred_init_ms;
+        record.code_pred_prefill_ms = timing.t_code_pred_prefill_ms;
+        record.code_pred_steps_ms = timing.t_code_pred_steps_ms;
+        record.code_pred_graph_build_ms = timing.t_code_pred_graph_build_ms;
+        record.code_pred_graph_alloc_ms = timing.t_code_pred_graph_alloc_ms;
+        record.code_pred_compute_ms = timing.t_code_pred_compute_ms;
+        record.code_pred_data_ms = timing.t_code_pred_data_ms;
+        record.code_pred_coreml_ms = timing.t_code_pred_coreml_ms;
+        record.embed_lookup_ms = timing.t_embed_lookup_ms;
+        record.frames = timing.n_frames;
+        record.generate_total_ms = timing.t_generate_total_ms;
+    }
+#endif
+
+    return record;
+}
+
+} // namespace
 
 void print_usage(const char * program) {
     fprintf(stderr, "Usage: %s [options] -m <model_dir> -t <text>\n", program);
@@ -29,6 +123,8 @@ void print_usage(const char * program) {
     fprintf(stderr, "  --speaker <name>       Use a built-in preset voice (CustomVoice models only)\n");
     fprintf(stderr, "  --list-speakers        List preset voices available in the loaded model and exit\n");
     fprintf(stderr, "  --ref-text <text>      Reference transcript (with -r) for ICL voice cloning\n");
+    fprintf(stderr, "  --benchmark-json <file> Write structured benchmark JSON after synthesis\n");
+    fprintf(stderr, "  --quiet-progress       Suppress CLI progress/status/timing output for benchmark runs\n");
     fprintf(stderr, "  -l, --language <lang>  Language: en,ru,zh,ja,ko,de,fr,es (default: en)\n");
     fprintf(stderr, "  -j, --threads <n>      Number of threads (default: 4)\n");
     fprintf(stderr, "  -h, --help             Show this help\n");
@@ -58,6 +154,8 @@ int main(int argc, char ** argv) {
     std::string speaker_preset;
     bool list_speakers = false;
     std::string ref_text;
+    std::string benchmark_json_file;
+    bool quiet_progress = false;
     
     qwen3_tts::tts_params params;
     
@@ -130,6 +228,14 @@ int main(int argc, char ** argv) {
                 return 1;
             }
             ref_text = argv[i];
+        } else if (arg == "--benchmark-json") {
+            if (++i >= argc) {
+                fprintf(stderr, "Error: missing benchmark JSON file\n");
+                return 1;
+            }
+            benchmark_json_file = argv[i];
+        } else if (arg == "--quiet-progress") {
+            quiet_progress = true;
         } else if (arg == "--temperature") {
             if (++i >= argc) {
                 fprintf(stderr, "Error: missing temperature value\n");
@@ -235,10 +341,17 @@ int main(int argc, char ** argv) {
         params.ref_text = ref_text;
     }
 
+    if (quiet_progress) {
+        params.print_progress = false;
+        params.print_timing = false;
+    }
+
     // Initialize TTS
     qwen3_tts::Qwen3TTS tts;
     
-    fprintf(stderr, "Loading models from: %s\n", model_dir.c_str());
+    if (!quiet_progress) {
+        fprintf(stderr, "Loading models from: %s\n", model_dir.c_str());
+    }
     if (!tts.load_models(model_dir, tts_model, tokenizer_model)) {
         fprintf(stderr, "Error: %s\n", tts.get_error().c_str());
         return 1;
@@ -267,15 +380,18 @@ int main(int argc, char ** argv) {
         return 0;
     }
 
-    // Set progress callback
-    tts.set_progress_callback([](int tokens, int max_tokens) {
-        fprintf(stderr, "\rGenerating: %d/%d tokens", tokens, max_tokens);
-    });
+    if (!quiet_progress) {
+        tts.set_progress_callback([](int tokens, int max_tokens) {
+            fprintf(stderr, "\rGenerating: %d/%d tokens", tokens, max_tokens);
+        });
+    }
 
     // Generate speech
     qwen3_tts::tts_result result;
+    std::string benchmark_mode;
 
     if (!speaker_preset.empty()) {
+        benchmark_mode = "preset";
         // Preset voice from CustomVoice model: resolve name → codec_embd row.
         std::vector<float> embedding;
         if (!tts.get_speaker_embedding(speaker_preset, embedding)) {
@@ -291,25 +407,36 @@ int main(int argc, char ** argv) {
             }
             return 1;
         }
-        fprintf(stderr, "Synthesizing with preset voice '%s' (%d dims): \"%s\"\n",
-                speaker_preset.c_str(), (int)embedding.size(), text.c_str());
+        if (!quiet_progress) {
+            fprintf(stderr, "Synthesizing with preset voice '%s' (%d dims): \"%s\"\n",
+                    speaker_preset.c_str(), (int)embedding.size(), text.c_str());
+        }
         result = tts.synthesize_with_embedding(text, embedding.data(), (int32_t)embedding.size(), params);
     } else if (!speaker_embedding_file.empty()) {
+        benchmark_mode = "speaker_embedding";
         // Use precomputed speaker embedding
         std::vector<float> embedding;
         if (!qwen3_tts::load_speaker_embedding(speaker_embedding_file, embedding)) {
             fprintf(stderr, "Error: failed to load speaker embedding from %s\n", speaker_embedding_file.c_str());
             return 1;
         }
-        fprintf(stderr, "Synthesizing with speaker embedding (%d dims): \"%s\"\n",
-                (int)embedding.size(), text.c_str());
+        if (!quiet_progress) {
+            fprintf(stderr, "Synthesizing with speaker embedding (%d dims): \"%s\"\n",
+                    (int)embedding.size(), text.c_str());
+        }
         result = tts.synthesize_with_embedding(text, embedding.data(), (int32_t)embedding.size(), params);
     } else if (reference_audio.empty()) {
-        fprintf(stderr, "Synthesizing: \"%s\"\n", text.c_str());
+        benchmark_mode = "default";
+        if (!quiet_progress) {
+            fprintf(stderr, "Synthesizing: \"%s\"\n", text.c_str());
+        }
         result = tts.synthesize(text, params);
     } else {
-        fprintf(stderr, "Synthesizing with voice cloning: \"%s\"\n", text.c_str());
-        fprintf(stderr, "Reference audio: %s\n", reference_audio.c_str());
+        benchmark_mode = ref_text.empty() ? "xvector_voice_clone" : "icl_voice_clone";
+        if (!quiet_progress) {
+            fprintf(stderr, "Synthesizing with voice cloning: \"%s\"\n", text.c_str());
+            fprintf(stderr, "Reference audio: %s\n", reference_audio.c_str());
+        }
 
         // Optionally dump the speaker embedding for reuse
         if (!dump_speaker_embedding_file.empty()) {
@@ -325,8 +452,10 @@ int main(int argc, char ** argv) {
                 return 1;
             }
             if (qwen3_tts::save_speaker_embedding(dump_speaker_embedding_file, embedding)) {
-                fprintf(stderr, "Speaker embedding saved to: %s (%d dims)\n",
-                        dump_speaker_embedding_file.c_str(), (int)embedding.size());
+                if (!quiet_progress) {
+                    fprintf(stderr, "Speaker embedding saved to: %s (%d dims)\n",
+                            dump_speaker_embedding_file.c_str(), (int)embedding.size());
+                }
             } else {
                 fprintf(stderr, "Warning: failed to save speaker embedding\n");
             }
@@ -340,7 +469,9 @@ int main(int argc, char ** argv) {
         return 1;
     }
     
-    fprintf(stderr, "\n");
+    if (!quiet_progress) {
+        fprintf(stderr, "\n");
+    }
     
     // Save output
     if (!qwen3_tts::save_audio_file(output_file, result.audio, result.sample_rate)) {
@@ -348,9 +479,24 @@ int main(int argc, char ** argv) {
         return 1;
     }
     
-    fprintf(stderr, "Output saved to: %s\n", output_file.c_str());
-    fprintf(stderr, "Audio duration: %.2f seconds\n", 
-            (float)result.audio.size() / result.sample_rate);
+    if (!quiet_progress) {
+        fprintf(stderr, "Output saved to: %s\n", output_file.c_str());
+        fprintf(stderr, "Audio duration: %.2f seconds\n",
+                (float)result.audio.size() / result.sample_rate);
+    }
+
+    if (!benchmark_json_file.empty()) {
+        const qwen3_tts::benchmark_record record =
+            make_benchmark_record(tts, result, params, benchmark_mode, text);
+        std::string error;
+        if (!qwen3_tts::write_benchmark_record_json(benchmark_json_file, record, error)) {
+            fprintf(stderr, "Error: %s\n", error.c_str());
+            return 1;
+        }
+        if (!quiet_progress) {
+            fprintf(stderr, "Benchmark JSON saved to: %s\n", benchmark_json_file.c_str());
+        }
+    }
     
     // Print timing
     if (params.print_timing) {

--- a/src/pipeline/qwen3_tts.cpp
+++ b/src/pipeline/qwen3_tts.cpp
@@ -387,6 +387,14 @@ void Qwen3TTS::set_n_threads(int32_t n_threads) {
     n_threads_ = n_threads;
     set_default_backend_n_threads(n_threads);
     apply_default_backend_threads_to_preferred_backend();
+    apply_n_threads(n_threads);
+}
+
+void Qwen3TTS::apply_n_threads(int32_t n_threads) {
+    if (n_threads <= 0) {
+        return;
+    }
+
     transformer_.set_n_threads(n_threads);
     audio_encoder_.set_n_threads(n_threads);
     codec_encoder_.set_n_threads(n_threads);
@@ -637,7 +645,8 @@ bool Qwen3TTS::prepare_icl_prompt(const std::string & reference_audio,
                                   const tts_params & params,
                                   icl_prompt & out) {
     std::unique_lock<std::mutex> lock(lifecycle_mutex_);
-    set_n_threads(effective_n_threads(params));
+    const int32_t call_n_threads = effective_n_threads(params);
+    apply_n_threads(call_n_threads);
 
     if (!models_loaded_) {
         error_msg_ = "Models not loaded";
@@ -675,7 +684,8 @@ bool Qwen3TTS::prepare_icl_prompt_from_samples(const float * ref_samples,
                                                const std::string & reference_text,
                                                const tts_params & params,
                                                icl_prompt & out) {
-    set_n_threads(effective_n_threads(params));
+    const int32_t call_n_threads = effective_n_threads(params);
+    apply_n_threads(call_n_threads);
 
     if (!models_loaded_) {
         error_msg_ = "Models not loaded";
@@ -698,6 +708,7 @@ bool Qwen3TTS::prepare_icl_prompt_from_samples(const float * ref_samples,
             return false;
         }
         encoder_loaded_ = true;
+        audio_encoder_.set_n_threads(call_n_threads);
         if (params.print_timing) {
             fprintf(stderr, "  Speaker encoder lazy-loaded in %lld ms\n",
                     (long long)(get_time_ms() - t_encoder_load_start));
@@ -732,6 +743,7 @@ bool Qwen3TTS::prepare_icl_prompt_from_samples(const float * ref_samples,
                 return false;
             }
             codec_encoder_loaded_ = true;
+            codec_encoder_.set_n_threads(call_n_threads);
             if (params.print_timing) {
                 fprintf(stderr, "  Codec encoder lazy-loaded in %lld ms\n",
                         (long long)(get_time_ms() - t_ce_start));
@@ -773,7 +785,8 @@ tts_result Qwen3TTS::synthesize_with_icl_prompt(const std::string & text,
                                                 const icl_prompt & prompt,
                                                 const tts_params & params) {
     std::unique_lock<std::mutex> lock(lifecycle_mutex_);
-    set_n_threads(effective_n_threads(params));
+    const int32_t call_n_threads = effective_n_threads(params);
+    apply_n_threads(call_n_threads);
     tts_result result;
     if (!models_loaded_) {
         result.error_msg = "Models not loaded";
@@ -850,7 +863,8 @@ bool Qwen3TTS::extract_speaker_embedding(const float * ref_samples, int32_t n_re
                                           std::vector<float> & embedding,
                                           const tts_params & params) {
     std::unique_lock<std::mutex> lock(lifecycle_mutex_);
-    set_n_threads(effective_n_threads(params));
+    const int32_t call_n_threads = effective_n_threads(params);
+    apply_n_threads(call_n_threads);
 
     if (!models_loaded_) {
         error_msg_ = "Models not loaded";
@@ -871,6 +885,9 @@ bool Qwen3TTS::extract_speaker_embedding_unlocked(const float * ref_samples,
                                                   int32_t n_ref_samples,
                                                   std::vector<float> & embedding,
                                                   const tts_params & params) {
+    const int32_t call_n_threads = effective_n_threads(params);
+    apply_n_threads(call_n_threads);
+
     if (!encoder_loaded_) {
         if (tts_model_path_.empty()) {
             error_msg_ = "Internal error: missing TTS model path for lazy encoder load";
@@ -882,6 +899,7 @@ bool Qwen3TTS::extract_speaker_embedding_unlocked(const float * ref_samples,
             return false;
         }
         encoder_loaded_ = true;
+        audio_encoder_.set_n_threads(call_n_threads);
         if (params.print_timing) {
             fprintf(stderr, "  Speaker encoder lazy-loaded in %lld ms\n",
                     (long long)(get_time_ms() - t_encoder_load_start));
@@ -938,7 +956,8 @@ tts_result Qwen3TTS::synthesize_internal_unlocked(const std::string & text,
                                                    tts_result & result,
                                                    const int32_t * ref_codes,
                                                    int32_t n_ref_frames) {
-    set_n_threads(effective_n_threads(params));
+    const int32_t call_n_threads = effective_n_threads(params);
+    apply_n_threads(call_n_threads);
 
     int64_t t_total_start = get_time_ms();
     auto sample_memory = [&](const char * stage) {
@@ -1002,6 +1021,7 @@ tts_result Qwen3TTS::synthesize_internal_unlocked(const std::string & text,
             return result;
         }
         transformer_loaded_ = true;
+        transformer_.set_n_threads(call_n_threads);
         if (params.print_timing) {
             fprintf(stderr, "  Transformer reloaded in %lld ms\n",
                     (long long)(get_time_ms() - t_reload_start));
@@ -1076,6 +1096,7 @@ tts_result Qwen3TTS::synthesize_internal_unlocked(const std::string & text,
             return result;
         }
         decoder_loaded_ = true;
+        audio_decoder_.set_n_threads(call_n_threads);
         if (params.print_timing) {
             fprintf(stderr, "  Vocoder lazy-loaded in %lld ms\n",
                     (long long)(get_time_ms() - t_decoder_load_start));

--- a/src/pipeline/qwen3_tts.cpp
+++ b/src/pipeline/qwen3_tts.cpp
@@ -1,4 +1,5 @@
 #include "pipeline/qwen3_tts.h"
+#include "common/backend_threads.h"
 #include "common/gguf_loader.h"
 #include "common/gpu_offload_policy.h"
 
@@ -378,6 +379,16 @@ const Qwen3TTS::model_metadata_snapshot & Qwen3TTS::metadata_snapshot_locked() c
     return empty;
 }
 
+void Qwen3TTS::set_n_threads(int32_t n_threads) {
+    if (n_threads <= 0) {
+        return;
+    }
+
+    set_default_backend_n_threads(n_threads);
+    apply_default_backend_threads_to_preferred_backend();
+    transformer_.set_n_threads(n_threads);
+}
+
 bool Qwen3TTS::load_models(const std::string & model_dir,
                            const std::string & tts_model,
                            const std::string & tokenizer_model) {
@@ -589,6 +600,10 @@ tts_result Qwen3TTS::synthesize_with_voice(const std::string & text,
                                             const tts_params & params) {
     std::unique_lock<std::mutex> lock(lifecycle_mutex_);
     tts_result result;
+
+    if (params.n_threads > 0) {
+        set_n_threads(params.n_threads);
+    }
     
     if (!models_loaded_) {
         result.error_msg = "Models not loaded";
@@ -686,6 +701,10 @@ bool Qwen3TTS::extract_speaker_embedding(const float * ref_samples, int32_t n_re
                                           std::vector<float> & embedding,
                                           const tts_params & params) {
     std::unique_lock<std::mutex> lock(lifecycle_mutex_);
+    if (params.n_threads > 0) {
+        set_n_threads(params.n_threads);
+    }
+
     if (!models_loaded_) {
         error_msg_ = "Models not loaded";
         return false;
@@ -772,6 +791,10 @@ tts_result Qwen3TTS::synthesize_internal_unlocked(const std::string & text,
                                                    tts_result & result,
                                                    const int32_t * ref_codes,
                                                    int32_t n_ref_frames) {
+    if (params.n_threads > 0) {
+        set_n_threads(params.n_threads);
+    }
+
     int64_t t_total_start = get_time_ms();
     auto sample_memory = [&](const char * stage) {
         process_memory_snapshot mem;

--- a/src/pipeline/qwen3_tts.cpp
+++ b/src/pipeline/qwen3_tts.cpp
@@ -387,6 +387,9 @@ void Qwen3TTS::set_n_threads(int32_t n_threads) {
     set_default_backend_n_threads(n_threads);
     apply_default_backend_threads_to_preferred_backend();
     transformer_.set_n_threads(n_threads);
+    audio_encoder_.set_n_threads(n_threads);
+    codec_encoder_.set_n_threads(n_threads);
+    audio_decoder_.set_n_threads(n_threads);
 }
 
 bool Qwen3TTS::load_models(const std::string & model_dir,

--- a/src/pipeline/qwen3_tts.cpp
+++ b/src/pipeline/qwen3_tts.cpp
@@ -868,6 +868,12 @@ tts_result Qwen3TTS::synthesize_internal_unlocked(const std::string & text,
         return result;
     }
     result.t_generate_ms = get_time_ms() - t_generate_start;
+#ifdef QWEN3_TTS_TIMING
+    if (const tts_timing * timing = transformer_.last_timing()) {
+        result.detailed_timing = *timing;
+        result.has_detailed_timing = true;
+    }
+#endif
     sample_memory("synth/after-generate");
     
     int n_codebooks = transformer_.get_config().n_codebooks;

--- a/src/pipeline/qwen3_tts.cpp
+++ b/src/pipeline/qwen3_tts.cpp
@@ -384,6 +384,7 @@ void Qwen3TTS::set_n_threads(int32_t n_threads) {
         return;
     }
 
+    n_threads_ = n_threads;
     set_default_backend_n_threads(n_threads);
     apply_default_backend_threads_to_preferred_backend();
     transformer_.set_n_threads(n_threads);
@@ -392,11 +393,16 @@ void Qwen3TTS::set_n_threads(int32_t n_threads) {
     audio_decoder_.set_n_threads(n_threads);
 }
 
+int32_t Qwen3TTS::effective_n_threads(const tts_params & params) const {
+    return params.n_threads > 0 ? params.n_threads : n_threads_;
+}
+
 bool Qwen3TTS::load_models(const std::string & model_dir,
                            const std::string & tts_model,
                            const std::string & tokenizer_model) {
     std::lock_guard<std::mutex> reload_lock(reload_mutex_);
     std::unique_lock<std::mutex> lock(lifecycle_mutex_);
+    set_n_threads(n_threads_);
 
     models_loaded_ = false;
     publish_metadata_snapshot_locked(std::make_shared<model_metadata_snapshot>());
@@ -604,9 +610,7 @@ tts_result Qwen3TTS::synthesize_with_voice(const std::string & text,
     std::unique_lock<std::mutex> lock(lifecycle_mutex_);
     tts_result result;
 
-    if (params.n_threads > 0) {
-        set_n_threads(params.n_threads);
-    }
+    set_n_threads(effective_n_threads(params));
     
     if (!models_loaded_) {
         result.error_msg = "Models not loaded";
@@ -704,9 +708,7 @@ bool Qwen3TTS::extract_speaker_embedding(const float * ref_samples, int32_t n_re
                                           std::vector<float> & embedding,
                                           const tts_params & params) {
     std::unique_lock<std::mutex> lock(lifecycle_mutex_);
-    if (params.n_threads > 0) {
-        set_n_threads(params.n_threads);
-    }
+    set_n_threads(effective_n_threads(params));
 
     if (!models_loaded_) {
         error_msg_ = "Models not loaded";
@@ -794,9 +796,7 @@ tts_result Qwen3TTS::synthesize_internal_unlocked(const std::string & text,
                                                    tts_result & result,
                                                    const int32_t * ref_codes,
                                                    int32_t n_ref_frames) {
-    if (params.n_threads > 0) {
-        set_n_threads(params.n_threads);
-    }
+    set_n_threads(effective_n_threads(params));
 
     int64_t t_total_start = get_time_ms();
     auto sample_memory = [&](const char * stage) {

--- a/src/pipeline/qwen3_tts.cpp
+++ b/src/pipeline/qwen3_tts.cpp
@@ -590,7 +590,7 @@ tts_result Qwen3TTS::synthesize_with_voice(const std::string & text,
         result.error_msg = "Failed to load reference audio: " + reference_audio;
         return result;
     }
-    
+
     const int target_rate = 24000;
     if (ref_sample_rate != target_rate) {
         fprintf(stderr, "Resampling audio from %d Hz to %d Hz...\n", ref_sample_rate, target_rate);
@@ -610,10 +610,13 @@ tts_result Qwen3TTS::synthesize_with_voice(const std::string & text,
     std::unique_lock<std::mutex> lock(lifecycle_mutex_);
     tts_result result;
 
-    set_n_threads(effective_n_threads(params));
-    
     if (!models_loaded_) {
         result.error_msg = "Models not loaded";
+        return result;
+    }
+
+    if (!ref_samples || n_ref_samples <= 0) {
+        result.error_msg = "Invalid reference audio samples";
         return result;
     }
 
@@ -629,20 +632,70 @@ tts_result Qwen3TTS::synthesize_with_voice(const std::string & text,
     return synthesize_with_voice_samples_unlocked(text, ref_samples, n_ref_samples, params, result);
 }
 
-tts_result Qwen3TTS::synthesize_with_voice_samples_unlocked(const std::string & text,
-                                                             const float * ref_samples,
-                                                             int32_t n_ref_samples,
-                                                             const tts_params & params,
-                                                             tts_result & result) {
+bool Qwen3TTS::prepare_icl_prompt(const std::string & reference_audio,
+                                  const std::string & reference_text,
+                                  const tts_params & params,
+                                  icl_prompt & out) {
+    std::unique_lock<std::mutex> lock(lifecycle_mutex_);
+    set_n_threads(effective_n_threads(params));
+
+    if (!models_loaded_) {
+        error_msg_ = "Models not loaded";
+        return false;
+    }
+
+    std::string resident_error;
+    if (!ensure_runtime_resident_locked(0u, resident_error)) {
+        error_msg_ = resident_error;
+        return false;
+    }
+    guarded_operation operation_guard(*this, true);
+
+    std::vector<float> ref_samples;
+    int ref_sample_rate;
+    if (!load_audio_file(reference_audio, ref_samples, ref_sample_rate)) {
+        error_msg_ = "Failed to load reference audio: " + reference_audio;
+        return false;
+    }
+
+    const int target_rate = 24000;
+    if (ref_sample_rate != target_rate) {
+        fprintf(stderr, "Resampling audio from %d Hz to %d Hz...\n", ref_sample_rate, target_rate);
+        std::vector<float> resampled;
+        resample_linear(ref_samples.data(), (int)ref_samples.size(), ref_sample_rate, resampled, target_rate);
+        ref_samples = std::move(resampled);
+    }
+
+    return prepare_icl_prompt_from_samples(ref_samples.data(), (int32_t)ref_samples.size(),
+                                           reference_text, params, out);
+}
+
+bool Qwen3TTS::prepare_icl_prompt_from_samples(const float * ref_samples,
+                                               int32_t n_ref_samples,
+                                               const std::string & reference_text,
+                                               const tts_params & params,
+                                               icl_prompt & out) {
+    set_n_threads(effective_n_threads(params));
+
+    if (!models_loaded_) {
+        error_msg_ = "Models not loaded";
+        return false;
+    }
+
+    if (!ref_samples || n_ref_samples <= 0) {
+        error_msg_ = "Invalid reference audio samples";
+        return false;
+    }
+
     if (!encoder_loaded_) {
         if (tts_model_path_.empty()) {
-            result.error_msg = "Internal error: missing TTS model path for lazy encoder load";
-            return result;
+            error_msg_ = "Internal error: missing TTS model path for lazy encoder load";
+            return false;
         }
         int64_t t_encoder_load_start = get_time_ms();
         if (!audio_encoder_.load_model(tts_model_path_)) {
-            result.error_msg = "Failed to load speaker encoder: " + audio_encoder_.get_error();
-            return result;
+            error_msg_ = "Failed to load speaker encoder: " + audio_encoder_.get_error();
+            return false;
         }
         encoder_loaded_ = true;
         if (params.print_timing) {
@@ -651,32 +704,30 @@ tts_result Qwen3TTS::synthesize_with_voice_samples_unlocked(const std::string & 
             log_memory_usage("voice/after-encoder-load");
         }
     }
-    
-    int64_t t_encode_start = get_time_ms();
-    std::vector<float> speaker_embedding;
 
-    if (!audio_encoder_.encode(ref_samples, n_ref_samples, speaker_embedding)) {
-        result.error_msg = "Failed to extract speaker embedding: " + audio_encoder_.get_error();
-        return result;
+    icl_prompt prepared;
+    prepared.ref_text = reference_text;
+    if (!audio_encoder_.encode(ref_samples, n_ref_samples, prepared.speaker_embedding)) {
+        error_msg_ = "Failed to extract speaker embedding: " + audio_encoder_.get_error();
+        return false;
     }
-    result.t_encode_ms = get_time_ms() - t_encode_start;
 
     if (params.print_progress) {
-        fprintf(stderr, "Speaker embedding extracted: %zu floats\n", speaker_embedding.size());
+        fprintf(stderr, "Speaker embedding extracted: %zu floats\n", prepared.speaker_embedding.size());
     }
 
     // ICL mode: also encode reference audio to discrete codec codes and thread
     // them + the reference transcript into the talker prefill.
-    if (!params.ref_text.empty()) {
+    if (!reference_text.empty()) {
         if (!codec_encoder_loaded_) {
             if (decoder_model_path_.empty()) {
-                result.error_msg = "Internal error: missing tokenizer model path for codec encoder";
-                return result;
+                error_msg_ = "Internal error: missing tokenizer model path for codec encoder";
+                return false;
             }
             int64_t t_ce_start = get_time_ms();
             if (!codec_encoder_.load_model(decoder_model_path_)) {
-                result.error_msg = "Failed to load Mimi codec encoder: " + codec_encoder_.get_error();
-                return result;
+                error_msg_ = "Failed to load Mimi codec encoder: " + codec_encoder_.get_error();
+                return false;
             }
             codec_encoder_loaded_ = true;
             if (params.print_timing) {
@@ -685,23 +736,80 @@ tts_result Qwen3TTS::synthesize_with_voice_samples_unlocked(const std::string & 
             }
         }
 
-        std::vector<int32_t> ref_codes;
-        int32_t n_ref_frames = 0;
-        int64_t t_ce_encode_start = get_time_ms();
-        if (!codec_encoder_.encode(ref_samples, n_ref_samples, ref_codes, n_ref_frames)) {
-            result.error_msg = "Failed to encode reference audio: " + codec_encoder_.get_error();
-            return result;
+        if (!codec_encoder_.encode(ref_samples, n_ref_samples,
+                                   prepared.ref_codes, prepared.n_ref_frames)) {
+            error_msg_ = "Failed to encode reference audio: " + codec_encoder_.get_error();
+            return false;
         }
-        result.t_encode_ms += get_time_ms() - t_ce_encode_start;
 
         if (params.print_progress) {
-            fprintf(stderr, "Reference codes: %d frames x 16 codebooks (ICL mode)\n", n_ref_frames);
+            fprintf(stderr, "Reference codes: %d frames x 16 codebooks (ICL mode)\n",
+                    prepared.n_ref_frames);
         }
-        return synthesize_internal_unlocked(text, speaker_embedding.data(), params, result,
-                                            ref_codes.data(), n_ref_frames);
     }
 
-    return synthesize_internal_unlocked(text, speaker_embedding.data(), params, result);
+    out = std::move(prepared);
+    return true;
+}
+
+tts_result Qwen3TTS::synthesize_with_voice_samples_unlocked(const std::string & text,
+                                                             const float * ref_samples,
+                                                             int32_t n_ref_samples,
+                                                             const tts_params & params,
+                                                             tts_result & result) {
+    icl_prompt prompt;
+    const int64_t t_encode_start = get_time_ms();
+    if (!prepare_icl_prompt_from_samples(ref_samples, n_ref_samples, params.ref_text, params, prompt)) {
+        result.error_msg = error_msg_;
+        return result;
+    }
+    result.t_encode_ms = get_time_ms() - t_encode_start;
+    return synthesize_with_icl_prompt_unlocked(text, prompt, params, result);
+}
+
+tts_result Qwen3TTS::synthesize_with_icl_prompt(const std::string & text,
+                                                const icl_prompt & prompt,
+                                                const tts_params & params) {
+    std::unique_lock<std::mutex> lock(lifecycle_mutex_);
+    set_n_threads(effective_n_threads(params));
+    tts_result result;
+    if (!models_loaded_) {
+        result.error_msg = "Models not loaded";
+        return result;
+    }
+
+    const uint32_t required = static_cast<uint32_t>(residency_component::transformer) |
+        static_cast<uint32_t>(residency_component::decoder);
+    std::string resident_error;
+    if (!ensure_runtime_resident_locked(required, resident_error)) {
+        result.error_msg = resident_error;
+        return result;
+    }
+    guarded_operation operation_guard(*this, true);
+
+    return synthesize_with_icl_prompt_unlocked(text, prompt, params, result);
+}
+
+tts_result Qwen3TTS::synthesize_with_icl_prompt_unlocked(const std::string & text,
+                                                         const icl_prompt & prompt,
+                                                         const tts_params & params,
+                                                         tts_result & result) {
+    if (prompt.speaker_embedding.empty()) {
+        result.error_msg = "Invalid prepared ICL prompt: missing speaker embedding";
+        return result;
+    }
+
+    tts_params prompt_params = params;
+    prompt_params.ref_text = prompt.ref_text;
+    const bool has_ref_codes = !prompt.ref_text.empty() &&
+                               prompt.n_ref_frames > 0 &&
+                               !prompt.ref_codes.empty();
+    return synthesize_internal_unlocked(text,
+                                        prompt.speaker_embedding.data(),
+                                        prompt_params,
+                                        result,
+                                        has_ref_codes ? prompt.ref_codes.data() : nullptr,
+                                        has_ref_codes ? prompt.n_ref_frames : 0);
 }
 
 bool Qwen3TTS::extract_speaker_embedding(const float * ref_samples, int32_t n_ref_samples,

--- a/src/pipeline/qwen3_tts.cpp
+++ b/src/pipeline/qwen3_tts.cpp
@@ -863,7 +863,8 @@ tts_result Qwen3TTS::synthesize_internal_unlocked(const std::string & text,
                                ref_text_tokens.empty() ? nullptr : ref_text_tokens.data(),
                                (int32_t)ref_text_tokens.size(),
                                icl_mode ? ref_codes : nullptr,
-                               icl_mode ? n_ref_frames : 0)) {
+                               icl_mode ? n_ref_frames : 0,
+                               params.print_timing)) {
         result.error_msg = "Failed to generate speech codes: " + transformer_.get_error();
         return result;
     }

--- a/src/pipeline/qwen3_tts.cpp
+++ b/src/pipeline/qwen3_tts.cpp
@@ -707,6 +707,8 @@ bool Qwen3TTS::prepare_icl_prompt_from_samples(const float * ref_samples,
 
     icl_prompt prepared;
     prepared.ref_text = reference_text;
+    prepared.expected_hidden_size = transformer_.get_config().hidden_size;
+    prepared.expected_n_codebooks = transformer_.get_config().n_codebooks;
     if (!audio_encoder_.encode(ref_samples, n_ref_samples, prepared.speaker_embedding)) {
         error_msg_ = "Failed to extract speaker embedding: " + audio_encoder_.get_error();
         return false;
@@ -799,11 +801,43 @@ tts_result Qwen3TTS::synthesize_with_icl_prompt_unlocked(const std::string & tex
         return result;
     }
 
+    const int32_t hidden_size = transformer_.get_config().hidden_size;
+    if (prompt.expected_hidden_size > 0 && prompt.expected_hidden_size != hidden_size) {
+        result.error_msg = "Invalid prepared ICL prompt: hidden_size mismatch: expected " +
+                           std::to_string(hidden_size) + " but prompt was prepared for " +
+                           std::to_string(prompt.expected_hidden_size);
+        return result;
+    }
+    if ((int32_t) prompt.speaker_embedding.size() != hidden_size) {
+        result.error_msg = "Invalid prepared ICL prompt: speaker embedding size mismatch: expected " +
+                           std::to_string(hidden_size) + " but got " +
+                           std::to_string(prompt.speaker_embedding.size());
+        return result;
+    }
+
+    const int32_t n_codebooks = transformer_.get_config().n_codebooks;
+    if (prompt.expected_n_codebooks > 0 && prompt.expected_n_codebooks != n_codebooks) {
+        result.error_msg = "Invalid prepared ICL prompt: n_codebooks mismatch: expected " +
+                           std::to_string(n_codebooks) + " but prompt was prepared for " +
+                           std::to_string(prompt.expected_n_codebooks);
+        return result;
+    }
+
     tts_params prompt_params = params;
     prompt_params.ref_text = prompt.ref_text;
     const bool has_ref_codes = !prompt.ref_text.empty() &&
                                prompt.n_ref_frames > 0 &&
                                !prompt.ref_codes.empty();
+    if (has_ref_codes) {
+        const size_t expected_codes = (size_t) prompt.n_ref_frames * (size_t) n_codebooks;
+        if (prompt.ref_codes.size() != expected_codes) {
+            result.error_msg = "Invalid prepared ICL prompt: reference code count mismatch: expected " +
+                               std::to_string(expected_codes) + " but got " +
+                               std::to_string(prompt.ref_codes.size());
+            return result;
+        }
+    }
+
     return synthesize_internal_unlocked(text,
                                         prompt.speaker_embedding.data(),
                                         prompt_params,

--- a/src/pipeline/qwen3_tts.cpp
+++ b/src/pipeline/qwen3_tts.cpp
@@ -788,6 +788,13 @@ tts_result Qwen3TTS::synthesize_with_icl_prompt(const std::string & text,
     const int32_t call_n_threads = effective_n_threads(params);
     apply_n_threads(call_n_threads);
     tts_result result;
+
+    std::string prompt_error;
+    if (!validate_icl_prompt_unlocked(prompt, prompt_error)) {
+        result.error_msg = prompt_error;
+        return result;
+    }
+
     if (!models_loaded_) {
         result.error_msg = "Models not loaded";
         return result;
@@ -809,30 +816,9 @@ tts_result Qwen3TTS::synthesize_with_icl_prompt_unlocked(const std::string & tex
                                                          const icl_prompt & prompt,
                                                          const tts_params & params,
                                                          tts_result & result) {
-    if (prompt.speaker_embedding.empty()) {
-        result.error_msg = "Invalid prepared ICL prompt: missing speaker embedding";
-        return result;
-    }
-
-    const int32_t hidden_size = transformer_.get_config().hidden_size;
-    if (prompt.expected_hidden_size > 0 && prompt.expected_hidden_size != hidden_size) {
-        result.error_msg = "Invalid prepared ICL prompt: hidden_size mismatch: expected " +
-                           std::to_string(hidden_size) + " but prompt was prepared for " +
-                           std::to_string(prompt.expected_hidden_size);
-        return result;
-    }
-    if ((int32_t) prompt.speaker_embedding.size() != hidden_size) {
-        result.error_msg = "Invalid prepared ICL prompt: speaker embedding size mismatch: expected " +
-                           std::to_string(hidden_size) + " but got " +
-                           std::to_string(prompt.speaker_embedding.size());
-        return result;
-    }
-
-    const int32_t n_codebooks = transformer_.get_config().n_codebooks;
-    if (prompt.expected_n_codebooks > 0 && prompt.expected_n_codebooks != n_codebooks) {
-        result.error_msg = "Invalid prepared ICL prompt: n_codebooks mismatch: expected " +
-                           std::to_string(n_codebooks) + " but prompt was prepared for " +
-                           std::to_string(prompt.expected_n_codebooks);
+    std::string prompt_error;
+    if (!validate_icl_prompt_unlocked(prompt, prompt_error)) {
+        result.error_msg = prompt_error;
         return result;
     }
 
@@ -841,15 +827,6 @@ tts_result Qwen3TTS::synthesize_with_icl_prompt_unlocked(const std::string & tex
     const bool has_ref_codes = !prompt.ref_text.empty() &&
                                prompt.n_ref_frames > 0 &&
                                !prompt.ref_codes.empty();
-    if (has_ref_codes) {
-        const size_t expected_codes = (size_t) prompt.n_ref_frames * (size_t) n_codebooks;
-        if (prompt.ref_codes.size() != expected_codes) {
-            result.error_msg = "Invalid prepared ICL prompt: reference code count mismatch: expected " +
-                               std::to_string(expected_codes) + " but got " +
-                               std::to_string(prompt.ref_codes.size());
-            return result;
-        }
-    }
 
     return synthesize_internal_unlocked(text,
                                         prompt.speaker_embedding.data(),
@@ -857,6 +834,50 @@ tts_result Qwen3TTS::synthesize_with_icl_prompt_unlocked(const std::string & tex
                                         result,
                                         has_ref_codes ? prompt.ref_codes.data() : nullptr,
                                         has_ref_codes ? prompt.n_ref_frames : 0);
+}
+
+bool Qwen3TTS::validate_icl_prompt_unlocked(const icl_prompt & prompt, std::string & error) const {
+    if (prompt.speaker_embedding.empty()) {
+        error = "Invalid prepared ICL prompt: missing speaker embedding";
+        return false;
+    }
+
+    const int32_t hidden_size = transformer_.get_config().hidden_size;
+    if (prompt.expected_hidden_size > 0 && prompt.expected_hidden_size != hidden_size) {
+        error = "Invalid prepared ICL prompt: hidden_size mismatch: expected " +
+                std::to_string(hidden_size) + " but prompt was prepared for " +
+                std::to_string(prompt.expected_hidden_size);
+        return false;
+    }
+    if ((int32_t) prompt.speaker_embedding.size() != hidden_size) {
+        error = "Invalid prepared ICL prompt: speaker embedding size mismatch: expected " +
+                std::to_string(hidden_size) + " but got " +
+                std::to_string(prompt.speaker_embedding.size());
+        return false;
+    }
+
+    const int32_t n_codebooks = transformer_.get_config().n_codebooks;
+    if (prompt.expected_n_codebooks > 0 && prompt.expected_n_codebooks != n_codebooks) {
+        error = "Invalid prepared ICL prompt: n_codebooks mismatch: expected " +
+                std::to_string(n_codebooks) + " but prompt was prepared for " +
+                std::to_string(prompt.expected_n_codebooks);
+        return false;
+    }
+
+    const bool has_ref_codes = !prompt.ref_text.empty() &&
+                               prompt.n_ref_frames > 0 &&
+                               !prompt.ref_codes.empty();
+    if (has_ref_codes) {
+        const size_t expected_codes = (size_t) prompt.n_ref_frames * (size_t) n_codebooks;
+        if (prompt.ref_codes.size() != expected_codes) {
+            error = "Invalid prepared ICL prompt: reference code count mismatch: expected " +
+                    std::to_string(expected_codes) + " but got " +
+                    std::to_string(prompt.ref_codes.size());
+            return false;
+        }
+    }
+
+    return true;
 }
 
 bool Qwen3TTS::extract_speaker_embedding(const float * ref_samples, int32_t n_ref_samples,

--- a/src/pipeline/qwen3_tts.h
+++ b/src/pipeline/qwen3_tts.h
@@ -172,6 +172,9 @@ public:
     // Set progress callback
     void set_progress_callback(tts_progress_callback_t callback);
 
+    // Set default backend thread count and apply it to loaded backends where supported.
+    void set_n_threads(int32_t n_threads);
+
     // Model metadata
     const std::string & get_model_type() const;  // "base" | "custom_voice" | "voice_design"
     const std::string & get_model_size() const;  // e.g. "0b6" | "1b7" (empty on older GGUFs)

--- a/src/pipeline/qwen3_tts.h
+++ b/src/pipeline/qwen3_tts.h
@@ -270,6 +270,7 @@ private:
                                                   const icl_prompt & prompt,
                                                   const tts_params & params,
                                                   tts_result & result);
+    bool validate_icl_prompt_unlocked(const icl_prompt & prompt, std::string & error) const;
     tts_result synthesize_internal_unlocked(const std::string & text,
                                             const float * speaker_embedding,
                                             const tts_params & params,

--- a/src/pipeline/qwen3_tts.h
+++ b/src/pipeline/qwen3_tts.h
@@ -225,6 +225,8 @@ private:
         std::vector<std::string> speaker_dialects;
     };
 
+    int32_t effective_n_threads(const tts_params & params) const;
+
     tts_result synthesize_with_voice_samples_unlocked(const std::string & text,
                                                       const float * ref_samples,
                                                       int32_t n_ref_samples,
@@ -268,6 +270,7 @@ private:
     bool transformer_loaded_ = false;
     bool decoder_loaded_ = false;
     bool low_mem_mode_ = false;
+    int32_t n_threads_ = 4;
     std::string error_msg_;
     std::string tts_model_path_;
     std::string decoder_model_path_;

--- a/src/pipeline/qwen3_tts.h
+++ b/src/pipeline/qwen3_tts.h
@@ -118,6 +118,14 @@ struct tts_result {
 // Progress callback type
 using tts_progress_callback_t = std::function<void(int tokens_generated, int max_tokens)>;
 
+// Prepared prompt state for voice cloning / ICL reuse.
+struct icl_prompt {
+    std::vector<float> speaker_embedding;
+    std::vector<int32_t> ref_codes;
+    int32_t n_ref_frames = 0;
+    std::string ref_text;
+};
+
 // Main TTS class that orchestrates the full pipeline
 class Qwen3TTS {
 public:
@@ -153,6 +161,17 @@ public:
     tts_result synthesize_with_voice(const std::string & text,
                                       const float * ref_samples, int32_t n_ref_samples,
                                       const tts_params & params = tts_params());
+
+    // Prepare reusable voice cloning / ICL prompt state from reference audio.
+    bool prepare_icl_prompt(const std::string & reference_audio,
+                            const std::string & reference_text,
+                            const tts_params & params,
+                            icl_prompt & out);
+
+    // Generate speech using previously prepared prompt state.
+    tts_result synthesize_with_icl_prompt(const std::string & text,
+                                          const icl_prompt & prompt,
+                                          const tts_params & params = tts_params());
     
     // Extract speaker embedding from raw audio samples (for caching)
     // ref_samples: 24kHz mono float32 normalized to [-1, 1]
@@ -199,6 +218,9 @@ public:
     const std::string & get_error() const { return error_msg_; }
 
     const std::string & get_tts_model_path() const { return tts_model_path_; }
+    const std::string & get_speaker_encoder_model_path() const { return tts_model_path_; }
+    const std::string & get_codec_encoder_model_path() const { return decoder_model_path_; }
+    const std::string & get_tokenizer_decoder_model_path() const { return decoder_model_path_; }
     const std::string & get_decoder_model_path() const { return decoder_model_path_; }
 
     // Check if models are loaded
@@ -227,11 +249,21 @@ private:
 
     int32_t effective_n_threads(const tts_params & params) const;
 
+    bool prepare_icl_prompt_from_samples(const float * ref_samples,
+                                         int32_t n_ref_samples,
+                                         const std::string & reference_text,
+                                         const tts_params & params,
+                                         icl_prompt & out);
+
     tts_result synthesize_with_voice_samples_unlocked(const std::string & text,
                                                       const float * ref_samples,
                                                       int32_t n_ref_samples,
                                                       const tts_params & params,
                                                       tts_result & result);
+    tts_result synthesize_with_icl_prompt_unlocked(const std::string & text,
+                                                  const icl_prompt & prompt,
+                                                  const tts_params & params,
+                                                  tts_result & result);
     tts_result synthesize_internal_unlocked(const std::string & text,
                                             const float * speaker_embedding,
                                             const tts_params & params,

--- a/src/pipeline/qwen3_tts.h
+++ b/src/pipeline/qwen3_tts.h
@@ -107,6 +107,11 @@ struct tts_result {
     uint64_t mem_phys_start_bytes = 0;
     uint64_t mem_phys_end_bytes = 0;
     uint64_t mem_phys_peak_bytes = 0;
+
+#ifdef QWEN3_TTS_TIMING
+    bool has_detailed_timing = false;
+    tts_timing detailed_timing = {};
+#endif
     
 };
 
@@ -189,6 +194,9 @@ public:
 
     // Get error message
     const std::string & get_error() const { return error_msg_; }
+
+    const std::string & get_tts_model_path() const { return tts_model_path_; }
+    const std::string & get_decoder_model_path() const { return decoder_model_path_; }
 
     // Check if models are loaded
     bool is_loaded() const;

--- a/src/pipeline/qwen3_tts.h
+++ b/src/pipeline/qwen3_tts.h
@@ -123,6 +123,8 @@ struct icl_prompt {
     std::vector<float> speaker_embedding;
     std::vector<int32_t> ref_codes;
     int32_t n_ref_frames = 0;
+    int32_t expected_hidden_size = 0;
+    int32_t expected_n_codebooks = 0;
     std::string ref_text;
 };
 

--- a/src/pipeline/qwen3_tts.h
+++ b/src/pipeline/qwen3_tts.h
@@ -45,8 +45,8 @@ struct tts_params {
     // Top-k sampling (0 = disabled)
     int32_t top_k = 50;
     
-    // Number of threads
-    int32_t n_threads = 4;
+    // Number of threads. 0 means use the engine's configured default.
+    int32_t n_threads = 0;
     
     // Print progress during generation
     bool print_progress = false;

--- a/src/pipeline/qwen3_tts.h
+++ b/src/pipeline/qwen3_tts.h
@@ -196,6 +196,9 @@ public:
     // Set default backend thread count and apply it to loaded backends where supported.
     void set_n_threads(int32_t n_threads);
 
+    // Get the configured default backend thread count.
+    int32_t get_n_threads() const { return n_threads_; }
+
     // Model metadata
     const std::string & get_model_type() const;  // "base" | "custom_voice" | "voice_design"
     const std::string & get_model_size() const;  // e.g. "0b6" | "1b7" (empty on older GGUFs)
@@ -250,6 +253,7 @@ private:
     };
 
     int32_t effective_n_threads(const tts_params & params) const;
+    void apply_n_threads(int32_t n_threads);
 
     bool prepare_icl_prompt_from_samples(const float * ref_samples,
                                          int32_t n_ref_samples,

--- a/src/pipeline/qwen3tts_c_api.cpp
+++ b/src/pipeline/qwen3tts_c_api.cpp
@@ -126,9 +126,6 @@ Qwen3TtsAudio * qwen3_tts_synthesize(
     if (!tts || !text) return nullptr;
     AUTORELEASE_BEGIN
     auto cpp_params = to_cpp_params(params);
-    if (cpp_params.n_threads > 0) {
-        tts->engine.set_n_threads(cpp_params.n_threads);
-    }
     auto result = tts->engine.synthesize(text, cpp_params);
     if (!result.success) {
         tts->last_error = result.error_msg;
@@ -160,9 +157,6 @@ Qwen3TtsAudio * qwen3_tts_synthesize_with_voice_file(
     if (!tts || !text || !reference_audio_path) return nullptr;
     AUTORELEASE_BEGIN
     auto cpp_params = to_cpp_params(params);
-    if (cpp_params.n_threads > 0) {
-        tts->engine.set_n_threads(cpp_params.n_threads);
-    }
     auto result = tts->engine.synthesize_with_voice(text, reference_audio_path, cpp_params);
     if (!result.success) {
         tts->last_error = result.error_msg;
@@ -179,9 +173,6 @@ Qwen3TtsAudio * qwen3_tts_synthesize_with_voice_samples(
     if (!tts || !text || !ref_samples || n_ref_samples <= 0) return nullptr;
     AUTORELEASE_BEGIN
     auto cpp_params = to_cpp_params(params);
-    if (cpp_params.n_threads > 0) {
-        tts->engine.set_n_threads(cpp_params.n_threads);
-    }
     auto result = tts->engine.synthesize_with_voice(text, ref_samples, n_ref_samples, cpp_params);
     if (!result.success) {
         tts->last_error = result.error_msg;
@@ -246,9 +237,6 @@ Qwen3TtsAudio * qwen3_tts_synthesize_with_embedding(
     if (!tts || !text || !embedding || embedding_size <= 0) return nullptr;
     AUTORELEASE_BEGIN
     auto cpp_params = to_cpp_params(params);
-    if (cpp_params.n_threads > 0) {
-        tts->engine.set_n_threads(cpp_params.n_threads);
-    }
     auto result = tts->engine.synthesize_with_embedding(text, embedding, embedding_size, cpp_params);
     if (!result.success) {
         tts->last_error = result.error_msg;
@@ -278,9 +266,6 @@ Qwen3TtsAudio * qwen3_tts_synthesize_icl_file(
     }
     AUTORELEASE_BEGIN
     auto cpp_params = to_cpp_params(params);
-    if (cpp_params.n_threads > 0) {
-        tts->engine.set_n_threads(cpp_params.n_threads);
-    }
     cpp_params.ref_text = reference_text;
     auto result = tts->engine.synthesize_with_voice(text, reference_audio_path, cpp_params);
     if (!result.success) {
@@ -307,9 +292,6 @@ Qwen3TtsIclPrompt * qwen3_tts_prepare_icl_prompt_file(
     }
     AUTORELEASE_BEGIN
     auto cpp_params = to_cpp_params(params);
-    if (cpp_params.n_threads > 0) {
-        tts->engine.set_n_threads(cpp_params.n_threads);
-    }
     auto * out = new Qwen3TtsIclPrompt;
     if (!tts->engine.prepare_icl_prompt(reference_audio_path, reference_text, cpp_params, out->prompt)) {
         tts->last_error = tts->engine.get_error();
@@ -336,9 +318,6 @@ Qwen3TtsAudio * qwen3_tts_synthesize_with_icl_prompt(
     }
     AUTORELEASE_BEGIN
     auto cpp_params = to_cpp_params(params);
-    if (cpp_params.n_threads > 0) {
-        tts->engine.set_n_threads(cpp_params.n_threads);
-    }
     auto result = tts->engine.synthesize_with_icl_prompt(text, prompt->prompt, cpp_params);
     if (!result.success) {
         tts->last_error = result.error_msg;

--- a/src/pipeline/qwen3tts_c_api.cpp
+++ b/src/pipeline/qwen3tts_c_api.cpp
@@ -101,7 +101,9 @@ void qwen3_tts_default_params(Qwen3TtsParams * params) {
 Qwen3Tts * qwen3_tts_create(const char * model_dir, int32_t n_threads) {
     if (!model_dir) return nullptr;
     auto * tts = new Qwen3Tts;
-    (void)n_threads; // thread count is set per-call via params
+    if (n_threads > 0) {
+        tts->engine.set_n_threads(n_threads);
+    }
     if (!tts->engine.load_models(model_dir)) {
         tts->last_error = tts->engine.get_error();
         delete tts;
@@ -120,6 +122,9 @@ Qwen3TtsAudio * qwen3_tts_synthesize(
     if (!tts || !text) return nullptr;
     AUTORELEASE_BEGIN
     auto cpp_params = to_cpp_params(params);
+    if (cpp_params.n_threads > 0) {
+        tts->engine.set_n_threads(cpp_params.n_threads);
+    }
     auto result = tts->engine.synthesize(text, cpp_params);
     if (!result.success) {
         tts->last_error = result.error_msg;
@@ -151,6 +156,9 @@ Qwen3TtsAudio * qwen3_tts_synthesize_with_voice_file(
     if (!tts || !text || !reference_audio_path) return nullptr;
     AUTORELEASE_BEGIN
     auto cpp_params = to_cpp_params(params);
+    if (cpp_params.n_threads > 0) {
+        tts->engine.set_n_threads(cpp_params.n_threads);
+    }
     auto result = tts->engine.synthesize_with_voice(text, reference_audio_path, cpp_params);
     if (!result.success) {
         tts->last_error = result.error_msg;
@@ -167,6 +175,9 @@ Qwen3TtsAudio * qwen3_tts_synthesize_with_voice_samples(
     if (!tts || !text || !ref_samples || n_ref_samples <= 0) return nullptr;
     AUTORELEASE_BEGIN
     auto cpp_params = to_cpp_params(params);
+    if (cpp_params.n_threads > 0) {
+        tts->engine.set_n_threads(cpp_params.n_threads);
+    }
     auto result = tts->engine.synthesize_with_voice(text, ref_samples, n_ref_samples, cpp_params);
     if (!result.success) {
         tts->last_error = result.error_msg;
@@ -231,6 +242,9 @@ Qwen3TtsAudio * qwen3_tts_synthesize_with_embedding(
     if (!tts || !text || !embedding || embedding_size <= 0) return nullptr;
     AUTORELEASE_BEGIN
     auto cpp_params = to_cpp_params(params);
+    if (cpp_params.n_threads > 0) {
+        tts->engine.set_n_threads(cpp_params.n_threads);
+    }
     auto result = tts->engine.synthesize_with_embedding(text, embedding, embedding_size, cpp_params);
     if (!result.success) {
         tts->last_error = result.error_msg;
@@ -248,6 +262,9 @@ Qwen3TtsAudio * qwen3_tts_synthesize_icl_file(
     if (!tts || !text || !reference_audio_path || !reference_text) return nullptr;
     AUTORELEASE_BEGIN
     auto cpp_params = to_cpp_params(params);
+    if (cpp_params.n_threads > 0) {
+        tts->engine.set_n_threads(cpp_params.n_threads);
+    }
     cpp_params.ref_text = reference_text;
     auto result = tts->engine.synthesize_with_voice(text, reference_audio_path, cpp_params);
     if (!result.success) {

--- a/src/pipeline/qwen3tts_c_api.cpp
+++ b/src/pipeline/qwen3tts_c_api.cpp
@@ -93,7 +93,7 @@ void qwen3_tts_default_params(Qwen3TtsParams * params) {
     params->temperature       = 0.9f;
     params->top_p             = 1.0f;
     params->top_k             = 50;
-    params->n_threads         = 4;
+    params->n_threads         = 0; // use handle default unless caller overrides
     params->repetition_penalty = 1.05f;
     params->language_id       = 2050; // en
 }

--- a/src/pipeline/qwen3tts_c_api.cpp
+++ b/src/pipeline/qwen3tts_c_api.cpp
@@ -52,6 +52,10 @@ struct Qwen3Tts {
     std::string last_error;
 };
 
+struct Qwen3TtsIclPrompt {
+    qwen3_tts::icl_prompt prompt;
+};
+
 // Helper: convert C params to C++ params
 static qwen3_tts::tts_params to_cpp_params(const Qwen3TtsParams * p) {
     qwen3_tts::tts_params params;
@@ -275,6 +279,51 @@ Qwen3TtsAudio * qwen3_tts_synthesize_icl_file(
     return out;
 }
 
+Qwen3TtsIclPrompt * qwen3_tts_prepare_icl_prompt_file(
+        Qwen3Tts * tts,
+        const char * reference_audio_path,
+        const char * reference_text,
+        const Qwen3TtsParams * params) {
+    if (!tts || !reference_audio_path || !reference_text) return nullptr;
+    AUTORELEASE_BEGIN
+    auto cpp_params = to_cpp_params(params);
+    if (cpp_params.n_threads > 0) {
+        tts->engine.set_n_threads(cpp_params.n_threads);
+    }
+    auto * out = new Qwen3TtsIclPrompt;
+    if (!tts->engine.prepare_icl_prompt(reference_audio_path, reference_text, cpp_params, out->prompt)) {
+        tts->last_error = tts->engine.get_error();
+        delete out;
+        out = nullptr;
+    }
+    AUTORELEASE_END
+    return out;
+}
+
+Qwen3TtsAudio * qwen3_tts_synthesize_with_icl_prompt(
+        Qwen3Tts * tts,
+        const char * text,
+        const Qwen3TtsIclPrompt * prompt,
+        const Qwen3TtsParams * params) {
+    if (!tts || !text || !prompt) return nullptr;
+    AUTORELEASE_BEGIN
+    auto cpp_params = to_cpp_params(params);
+    if (cpp_params.n_threads > 0) {
+        tts->engine.set_n_threads(cpp_params.n_threads);
+    }
+    auto result = tts->engine.synthesize_with_icl_prompt(text, prompt->prompt, cpp_params);
+    if (!result.success) {
+        tts->last_error = result.error_msg;
+    }
+    auto * out = to_c_audio(result);
+    AUTORELEASE_END
+    return out;
+}
+
+void qwen3_tts_free_icl_prompt(Qwen3TtsIclPrompt * prompt) {
+    delete prompt;
+}
+
 const char * qwen3_tts_get_error(const Qwen3Tts * tts) {
     if (!tts) return "";
     return tts->last_error.c_str();
@@ -288,6 +337,26 @@ const char * qwen3_tts_model_type(const Qwen3Tts * tts) {
 const char * qwen3_tts_model_size(const Qwen3Tts * tts) {
     if (!tts) return "";
     return tts->engine.get_model_size().c_str();
+}
+
+const char * qwen3_tts_tts_model_path(const Qwen3Tts * tts) {
+    if (!tts) return "";
+    return tts->engine.get_tts_model_path().c_str();
+}
+
+const char * qwen3_tts_speaker_encoder_model_path(const Qwen3Tts * tts) {
+    if (!tts) return "";
+    return tts->engine.get_speaker_encoder_model_path().c_str();
+}
+
+const char * qwen3_tts_codec_encoder_model_path(const Qwen3Tts * tts) {
+    if (!tts) return "";
+    return tts->engine.get_codec_encoder_model_path().c_str();
+}
+
+const char * qwen3_tts_tokenizer_decoder_model_path(const Qwen3Tts * tts) {
+    if (!tts) return "";
+    return tts->engine.get_tokenizer_decoder_model_path().c_str();
 }
 
 int qwen3_tts_has_speaker_encoder(const Qwen3Tts * tts) {

--- a/src/pipeline/qwen3tts_c_api.cpp
+++ b/src/pipeline/qwen3tts_c_api.cpp
@@ -263,7 +263,19 @@ Qwen3TtsAudio * qwen3_tts_synthesize_icl_file(
         const char * reference_audio_path,
         const char * reference_text,
         const Qwen3TtsParams * params) {
-    if (!tts || !text || !reference_audio_path || !reference_text) return nullptr;
+    if (!tts) return nullptr;
+    if (!text) {
+        tts->last_error = "Invalid argument: text is null";
+        return nullptr;
+    }
+    if (!reference_audio_path) {
+        tts->last_error = "Invalid argument: reference_audio_path is null";
+        return nullptr;
+    }
+    if (!reference_text) {
+        tts->last_error = "Invalid argument: reference_text is null";
+        return nullptr;
+    }
     AUTORELEASE_BEGIN
     auto cpp_params = to_cpp_params(params);
     if (cpp_params.n_threads > 0) {
@@ -284,7 +296,15 @@ Qwen3TtsIclPrompt * qwen3_tts_prepare_icl_prompt_file(
         const char * reference_audio_path,
         const char * reference_text,
         const Qwen3TtsParams * params) {
-    if (!tts || !reference_audio_path || !reference_text) return nullptr;
+    if (!tts) return nullptr;
+    if (!reference_audio_path) {
+        tts->last_error = "Invalid argument: reference_audio_path is null";
+        return nullptr;
+    }
+    if (!reference_text) {
+        tts->last_error = "Invalid argument: reference_text is null";
+        return nullptr;
+    }
     AUTORELEASE_BEGIN
     auto cpp_params = to_cpp_params(params);
     if (cpp_params.n_threads > 0) {
@@ -305,7 +325,15 @@ Qwen3TtsAudio * qwen3_tts_synthesize_with_icl_prompt(
         const char * text,
         const Qwen3TtsIclPrompt * prompt,
         const Qwen3TtsParams * params) {
-    if (!tts || !text || !prompt) return nullptr;
+    if (!tts) return nullptr;
+    if (!text) {
+        tts->last_error = "Invalid argument: text is null";
+        return nullptr;
+    }
+    if (!prompt) {
+        tts->last_error = "Invalid argument: prompt is null";
+        return nullptr;
+    }
     AUTORELEASE_BEGIN
     auto cpp_params = to_cpp_params(params);
     if (cpp_params.n_threads > 0) {

--- a/src/pipeline/qwen3tts_c_api.h
+++ b/src/pipeline/qwen3tts_c_api.h
@@ -17,7 +17,7 @@ typedef struct Qwen3TtsParams {
     float   temperature;         /* default: 0.9, 0=greedy */
     float   top_p;               /* default: 1.0 */
     int32_t top_k;               /* default: 50, 0=disabled */
-    int32_t n_threads;           /* default: 4 */
+    int32_t n_threads;           /* default: 0 (use handle default) */
     float   repetition_penalty;  /* default: 1.05 */
     int32_t language_id;         /* 2050=en, 2058=ja, 2055=zh, etc. */
 } Qwen3TtsParams;

--- a/src/pipeline/qwen3tts_c_api.h
+++ b/src/pipeline/qwen3tts_c_api.h
@@ -10,6 +10,7 @@ extern "C" {
 
 /* Opaque handle */
 typedef struct Qwen3Tts Qwen3Tts;
+typedef struct Qwen3TtsIclPrompt Qwen3TtsIclPrompt;
 
 /* Generation parameters */
 typedef struct Qwen3TtsParams {
@@ -112,6 +113,26 @@ Qwen3TtsAudio* qwen3_tts_synthesize_icl_file(
     const char* reference_text,
     const Qwen3TtsParams* params);
 
+/* Prepare reusable in-context-learning prompt state from a reference WAV and
+ * transcript. Caller must free the returned handle with
+ * qwen3_tts_free_icl_prompt(). */
+Qwen3TtsIclPrompt* qwen3_tts_prepare_icl_prompt_file(
+    Qwen3Tts* tts,
+    const char* reference_audio_path,
+    const char* reference_text,
+    const Qwen3TtsParams* params);
+
+/* Synthesize using a prompt returned by qwen3_tts_prepare_icl_prompt_file().
+ * Returns NULL on failure. Caller must free with qwen3_tts_free_audio(). */
+Qwen3TtsAudio* qwen3_tts_synthesize_with_icl_prompt(
+    Qwen3Tts* tts,
+    const char* text,
+    const Qwen3TtsIclPrompt* prompt,
+    const Qwen3TtsParams* params);
+
+/* Free a prepared ICL prompt handle. */
+void qwen3_tts_free_icl_prompt(Qwen3TtsIclPrompt* prompt);
+
 /* Get last error message (or empty string) */
 const char* qwen3_tts_get_error(const Qwen3Tts* tts);
 
@@ -123,6 +144,14 @@ const char* qwen3_tts_model_type(const Qwen3Tts* tts);
 
 /* Returns the model size tag: "0b6", "1b7", etc. Empty on older GGUFs. */
 const char* qwen3_tts_model_size(const Qwen3Tts* tts);
+
+/* Resolved model paths used by each role that can affect prepared ICL output.
+ * Roles may currently point to the same GGUF path but are exposed separately
+ * for stable cache keys across future split-model layouts. */
+const char* qwen3_tts_tts_model_path(const Qwen3Tts* tts);
+const char* qwen3_tts_speaker_encoder_model_path(const Qwen3Tts* tts);
+const char* qwen3_tts_codec_encoder_model_path(const Qwen3Tts* tts);
+const char* qwen3_tts_tokenizer_decoder_model_path(const Qwen3Tts* tts);
 
 /* Returns 1 if the model ships an ECAPA-TDNN speaker encoder, else 0. */
 int qwen3_tts_has_speaker_encoder(const Qwen3Tts* tts);

--- a/src/transformer/tts_transformer.cpp
+++ b/src/transformer/tts_transformer.cpp
@@ -1,4 +1,5 @@
 #include "transformer/tts_transformer.h"
+#include "common/backend_threads.h"
 #include "common/gguf_loader.h"
 
 #include <cmath>
@@ -168,6 +169,7 @@ bool TTSTransformer::load_model(const std::string & model_path) {
             error_msg_ = "Failed to initialize CPU fallback backend for TTSTransformer";
             return false;
         }
+        apply_backend_n_threads(state_.backend_cpu, get_default_backend_n_threads());
     }
     
     if (!create_transformer_scheduler(state_, error_msg_)) {
@@ -301,6 +303,21 @@ bool TTSTransformer::require_weights_gpu_resident() {
         return false;
     }
     return true;
+}
+
+bool TTSTransformer::set_n_threads(int32_t n_threads) {
+    if (n_threads <= 0) {
+        return false;
+    }
+
+    bool applied = false;
+    if (state_.backend) {
+        applied = apply_backend_n_threads(state_.backend, n_threads) || applied;
+    }
+    if (state_.backend_cpu) {
+        applied = apply_backend_n_threads(state_.backend_cpu, n_threads) || applied;
+    }
+    return applied;
 }
 
 bool TTSTransformer::try_init_coreml_code_predictor(const std::string & model_path) {

--- a/src/transformer/tts_transformer.cpp
+++ b/src/transformer/tts_transformer.cpp
@@ -3028,7 +3028,12 @@ bool TTSTransformer::generate(const int32_t * text_tokens, int32_t n_tokens,
     tts_timing timing = {};
     auto t_gen_start = clk::now();
     auto t0 = t_gen_start, t1 = t_gen_start;
+    has_last_timing_ = false;
     timing_ = &timing;
+    struct timing_scope {
+        tts_timing *& active;
+        ~timing_scope() { active = nullptr; }
+    } timing_scope_guard{timing_};
 #endif
 
     if (!model_.ctx) {
@@ -3249,7 +3254,8 @@ bool TTSTransformer::generate(const int32_t * text_tokens, int32_t n_tokens,
     
 #ifdef QWEN3_TTS_TIMING
     timing.t_generate_total_ms = std::chrono::duration<double, std::milli>(clk::now() - t_gen_start).count();
-    timing_ = nullptr;
+    last_timing_ = timing;
+    has_last_timing_ = true;
     const auto & t = timing;
     int nf = t.n_frames;
     fprintf(stderr, "\n=== Detailed Generation Timing (%d frames) ===\n", nf);
@@ -3293,6 +3299,12 @@ bool TTSTransformer::generate(const int32_t * text_tokens, int32_t n_tokens,
 
     return true;
 }
+
+#ifdef QWEN3_TTS_TIMING
+const tts_timing * TTSTransformer::last_timing() const {
+    return has_last_timing_ ? &last_timing_ : nullptr;
+}
+#endif
 
 bool TTSTransformer::forward(const int32_t * tokens, int32_t n_tokens, int32_t n_past,
                               std::vector<float> & output) {

--- a/src/transformer/tts_transformer.cpp
+++ b/src/transformer/tts_transformer.cpp
@@ -3018,7 +3018,8 @@ bool TTSTransformer::generate(const int32_t * text_tokens, int32_t n_tokens,
                                const int32_t * ref_text_tokens,
                                int32_t n_ref_text_tokens,
                                const int32_t * ref_codes,
-                               int32_t n_ref_frames) {
+                               int32_t n_ref_frames,
+                               bool print_timing) {
     if (!require_weights_gpu_resident()) {
         return false;
     }
@@ -3256,6 +3257,10 @@ bool TTSTransformer::generate(const int32_t * text_tokens, int32_t n_tokens,
     timing.t_generate_total_ms = std::chrono::duration<double, std::milli>(clk::now() - t_gen_start).count();
     last_timing_ = timing;
     has_last_timing_ = true;
+    if (!print_timing) {
+        return true;
+    }
+
     const auto & t = timing;
     int nf = t.n_frames;
     fprintf(stderr, "\n=== Detailed Generation Timing (%d frames) ===\n", nf);

--- a/src/transformer/tts_transformer.h
+++ b/src/transformer/tts_transformer.h
@@ -332,6 +332,9 @@ public:
 
     // Force f32 accumulation in matmul (improves quality on some GPUs, default: on)
     void set_f32_acc(bool v) { f32_acc_ = v; }
+
+    // Apply thread count to loaded GGML backends where supported.
+    bool set_n_threads(int32_t n_threads);
     
     // Legacy interface for compatibility
     bool forward(const int32_t * tokens, int32_t n_tokens, int32_t n_past,

--- a/src/transformer/tts_transformer.h
+++ b/src/transformer/tts_transformer.h
@@ -316,7 +316,8 @@ public:
                   const int32_t * ref_text_tokens = nullptr,
                   int32_t n_ref_text_tokens = 0,
                   const int32_t * ref_codes = nullptr,
-                  int32_t n_ref_frames = 0);
+                  int32_t n_ref_frames = 0,
+                  bool print_timing = true);
     
     const tts_transformer_config & get_config() const { return model_.config; }
 

--- a/src/transformer/tts_transformer.h
+++ b/src/transformer/tts_transformer.h
@@ -322,6 +322,10 @@ public:
 
     const std::string & get_error() const { return error_msg_; }
 
+#ifdef QWEN3_TTS_TIMING
+    const tts_timing * last_timing() const;
+#endif
+
     // Set RNG seed for reproducible output
     void set_seed(uint32_t seed) { rng_.seed(seed); }
 
@@ -409,6 +413,8 @@ private:
 
 #ifdef QWEN3_TTS_TIMING
     tts_timing * timing_ = nullptr;
+    tts_timing last_timing_ = {};
+    bool has_last_timing_ = false;
 #endif
 };
 

--- a/tests/test_backend_threads.cpp
+++ b/tests/test_backend_threads.cpp
@@ -1,0 +1,23 @@
+#include "common/backend_threads.h"
+#include "ggml-backend.h"
+
+#include <cassert>
+
+int main() {
+    ggml_backend_t cpu = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, nullptr);
+    assert(cpu != nullptr);
+
+    assert(qwen3_tts::apply_backend_n_threads(cpu, 1));
+    assert(qwen3_tts::apply_backend_n_threads(cpu, 2));
+    assert(!qwen3_tts::apply_backend_n_threads(nullptr, 2));
+    assert(!qwen3_tts::apply_backend_n_threads(cpu, 0));
+    assert(!qwen3_tts::apply_backend_n_threads(cpu, -1));
+
+    qwen3_tts::set_default_backend_n_threads(3);
+    assert(qwen3_tts::get_default_backend_n_threads() == 3);
+    qwen3_tts::set_default_backend_n_threads(0);
+    assert(qwen3_tts::get_default_backend_n_threads() == 3);
+
+    ggml_backend_free(cpu);
+    return 0;
+}

--- a/tests/test_backend_threads.cpp
+++ b/tests/test_backend_threads.cpp
@@ -1,4 +1,5 @@
 #include "common/backend_threads.h"
+#include "pipeline/qwen3_tts.h"
 #include "ggml-backend.h"
 
 #include <cassert>
@@ -19,5 +20,22 @@ int main() {
     assert(qwen3_tts::get_default_backend_n_threads() == 3);
 
     ggml_backend_free(cpu);
+
+    qwen3_tts::Qwen3TTS engine;
+    engine.set_n_threads(8);
+    assert(qwen3_tts::get_default_backend_n_threads() == 8);
+
+    qwen3_tts::tts_params default_params;
+    assert(default_params.n_threads == 0);
+    auto unloaded_result = engine.synthesize_with_voice("thread regression", nullptr, 0, default_params);
+    assert(!unloaded_result.success);
+    assert(qwen3_tts::get_default_backend_n_threads() == 8);
+
+    qwen3_tts::tts_params override_params;
+    override_params.n_threads = 6;
+    unloaded_result = engine.synthesize_with_voice("thread override", nullptr, 0, override_params);
+    assert(!unloaded_result.success);
+    assert(qwen3_tts::get_default_backend_n_threads() == 6);
+
     return 0;
 }

--- a/tests/test_backend_threads.cpp
+++ b/tests/test_backend_threads.cpp
@@ -24,6 +24,7 @@ int main() {
 
     qwen3_tts::Qwen3TTS engine;
     engine.set_n_threads(8);
+    assert(engine.get_n_threads() == 8);
     assert(qwen3_tts::get_default_backend_n_threads() == 8);
 
     qwen3_tts::tts_params default_params;
@@ -36,22 +37,29 @@ int main() {
     override_params.n_threads = 6;
     unloaded_result = engine.synthesize_with_voice("thread override", nullptr, 0, override_params);
     assert(!unloaded_result.success);
-    assert(qwen3_tts::get_default_backend_n_threads() == 6);
+    assert(engine.get_n_threads() == 8);
+    assert(qwen3_tts::get_default_backend_n_threads() == 8);
 
     qwen3_tts::Qwen3TTS engine_a;
     qwen3_tts::Qwen3TTS engine_b;
     engine_a.set_n_threads(8);
     engine_b.set_n_threads(5);
+    assert(engine_a.get_n_threads() == 8);
+    assert(engine_b.get_n_threads() == 5);
     assert(qwen3_tts::get_default_backend_n_threads() == 5);
 
     qwen3_tts::tts_params no_override_params;
     assert(no_override_params.n_threads == 0);
     unloaded_result = engine_a.synthesize_with_voice("engine a default", nullptr, 0, no_override_params);
     assert(!unloaded_result.success);
-    assert(qwen3_tts::get_default_backend_n_threads() == 8);
+    assert(engine_a.get_n_threads() == 8);
+    assert(engine_b.get_n_threads() == 5);
+    assert(qwen3_tts::get_default_backend_n_threads() == 5);
 
     unloaded_result = engine_b.synthesize_with_voice("engine b default", nullptr, 0, no_override_params);
     assert(!unloaded_result.success);
+    assert(engine_a.get_n_threads() == 8);
+    assert(engine_b.get_n_threads() == 5);
     assert(qwen3_tts::get_default_backend_n_threads() == 5);
 
     qwen3_tts::Qwen3TTS prompt_engine;

--- a/tests/test_backend_threads.cpp
+++ b/tests/test_backend_threads.cpp
@@ -3,6 +3,7 @@
 #include "ggml-backend.h"
 
 #include <cassert>
+#include <string>
 
 int main() {
     ggml_backend_t cpu = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, nullptr);
@@ -52,6 +53,28 @@ int main() {
     unloaded_result = engine_b.synthesize_with_voice("engine b default", nullptr, 0, no_override_params);
     assert(!unloaded_result.success);
     assert(qwen3_tts::get_default_backend_n_threads() == 5);
+
+    qwen3_tts::Qwen3TTS prompt_engine;
+    qwen3_tts::icl_prompt wrong_prompt;
+    wrong_prompt.expected_hidden_size = 2048;
+    wrong_prompt.expected_n_codebooks = 16;
+    wrong_prompt.speaker_embedding.assign((size_t) wrong_prompt.expected_hidden_size, 0.0f);
+    auto prompt_result = prompt_engine.synthesize_with_icl_prompt(
+        "prompt mismatch", wrong_prompt, no_override_params);
+    assert(!prompt_result.success);
+    assert(prompt_result.error_msg.find("hidden_size mismatch") != std::string::npos);
+
+    qwen3_tts::icl_prompt wrong_codes_prompt;
+    wrong_codes_prompt.expected_hidden_size = 1024;
+    wrong_codes_prompt.expected_n_codebooks = 8;
+    wrong_codes_prompt.speaker_embedding.assign((size_t) wrong_codes_prompt.expected_hidden_size, 0.0f);
+    wrong_codes_prompt.ref_text = "reference";
+    wrong_codes_prompt.n_ref_frames = 1;
+    wrong_codes_prompt.ref_codes.assign((size_t) wrong_codes_prompt.expected_n_codebooks, 0);
+    prompt_result = prompt_engine.synthesize_with_icl_prompt(
+        "codebook mismatch", wrong_codes_prompt, no_override_params);
+    assert(!prompt_result.success);
+    assert(prompt_result.error_msg.find("n_codebooks mismatch") != std::string::npos);
 
     return 0;
 }

--- a/tests/test_backend_threads.cpp
+++ b/tests/test_backend_threads.cpp
@@ -37,5 +37,21 @@ int main() {
     assert(!unloaded_result.success);
     assert(qwen3_tts::get_default_backend_n_threads() == 6);
 
+    qwen3_tts::Qwen3TTS engine_a;
+    qwen3_tts::Qwen3TTS engine_b;
+    engine_a.set_n_threads(8);
+    engine_b.set_n_threads(5);
+    assert(qwen3_tts::get_default_backend_n_threads() == 5);
+
+    qwen3_tts::tts_params no_override_params;
+    assert(no_override_params.n_threads == 0);
+    unloaded_result = engine_a.synthesize_with_voice("engine a default", nullptr, 0, no_override_params);
+    assert(!unloaded_result.success);
+    assert(qwen3_tts::get_default_backend_n_threads() == 8);
+
+    unloaded_result = engine_b.synthesize_with_voice("engine b default", nullptr, 0, no_override_params);
+    assert(!unloaded_result.success);
+    assert(qwen3_tts::get_default_backend_n_threads() == 5);
+
     return 0;
 }

--- a/tests/test_benchmark_json.cpp
+++ b/tests/test_benchmark_json.cpp
@@ -7,6 +7,8 @@ int main() {
     qwen3_tts::benchmark_record r;
     r.mode = "default";
     r.backend = "cpu";
+    r.tts_model = "qwen3-tts-0.6b-q8_0.gguf";
+    r.decoder_model = "qwen3-tts-tokenizer-f16.gguf";
     r.text = "hello \"tts\"\nnext";
     r.audio_seconds = 2.0;
     r.total_ms = 1000;
@@ -18,6 +20,9 @@ int main() {
 
     const std::string json = qwen3_tts::benchmark_record_to_json(r);
     assert(json.find("\"mode\":\"default\"") != std::string::npos);
+    assert(json.find("\"tts_model\":\"qwen3-tts-0.6b-q8_0.gguf\"") != std::string::npos);
+    assert(json.find("\"decoder_model\":\"qwen3-tts-tokenizer-f16.gguf\"") != std::string::npos);
+    assert(json.find("\"tokenizer_model\"") == std::string::npos);
     assert(json.find("hello \\\"tts\\\"\\nnext") != std::string::npos);
     assert(json.find("\"speed_x_realtime\":2") != std::string::npos);
     assert(json.find("\"wall_rtf\":0.5") != std::string::npos);

--- a/tests/test_benchmark_json.cpp
+++ b/tests/test_benchmark_json.cpp
@@ -1,0 +1,35 @@
+#include "common/benchmark_json.h"
+
+#include <cassert>
+#include <string>
+
+int main() {
+    qwen3_tts::benchmark_record r;
+    r.mode = "default";
+    r.backend = "cpu";
+    r.text = "hello \"tts\"\nnext";
+    r.audio_seconds = 2.0;
+    r.total_ms = 1000;
+    r.generate_ms = 700;
+    r.mem_rss_start_bytes = 1024;
+    r.mem_rss_end_bytes = 2048;
+    r.has_detailed_timing = true;
+    r.prefill_graph_build_ms = 1.25;
+
+    const std::string json = qwen3_tts::benchmark_record_to_json(r);
+    assert(json.find("\"mode\":\"default\"") != std::string::npos);
+    assert(json.find("hello \\\"tts\\\"\\nnext") != std::string::npos);
+    assert(json.find("\"speed_x_realtime\":2") != std::string::npos);
+    assert(json.find("\"wall_rtf\":0.5") != std::string::npos);
+    assert(json.find("\"mem_rss_start_bytes\":1024") != std::string::npos);
+    assert(json.find("\"prefill_graph_build_ms\":1.25") != std::string::npos);
+
+    qwen3_tts::benchmark_record zero;
+    zero.audio_seconds = 0.0;
+    zero.total_ms = 0;
+    const std::string zero_json = qwen3_tts::benchmark_record_to_json(zero);
+    assert(zero_json.find("\"speed_x_realtime\"") == std::string::npos);
+    assert(zero_json.find("\"wall_rtf\"") == std::string::npos);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Add structured benchmark JSON output and document repeatable benchmark runs.
- Propagate cross-platform GGML thread controls through CLI, C API, server binding, transformer, encoder, codec encoder, and decoder paths.
- Add bounded prepared ICL prompt caching for repeated server reference-audio requests, with model-aware cache keys and docs.

## Test Plan
- cmake --build build-perf -j4
- git diff --check
- ctest --test-dir build-perf -R "benchmark_json_test|backend_threads_test" --output-on-failure
- python3 server/tests/test_icl_cache.py
- env QWEN3_TTS_BACKEND=cpu ./build-perf/qwen3-tts-cli -m /Users/macbook-dev/Documents/GitHub/qwen3-tts.cpp/models --tts-model qwen3-tts-0.6b-q8_0.gguf -t "Benchmark smoke test." --seed 1234 --max-tokens 16 --benchmark-json /tmp/qwen3-tts-final-smoke.json --quiet-progress -o /tmp/qwen3-tts-final-smoke.wav